### PR TITLE
feat(qmd-client): add concurrency lock for update/embed (QMD2-003)

### DIFF
--- a/packages/qmd-client/index.test.ts
+++ b/packages/qmd-client/index.test.ts
@@ -279,6 +279,82 @@ describe("qmd-client", () => {
     });
   });
 
+  // ─── Concurrency Lock ──────────────────────────────────────
+
+  describe("concurrency lock", () => {
+    test("update() and embed() do not run concurrently", async () => {
+      await initStore("/tmp/test.sqlite");
+
+      const executionLog: string[] = [];
+
+      (mockStore.update as ReturnType<typeof mock>).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            executionLog.push("update-start");
+            setTimeout(() => {
+              executionLog.push("update-end");
+              resolve({
+                collections: 1,
+                indexed: 5,
+                updated: 2,
+                unchanged: 3,
+                removed: 0,
+                needsEmbedding: 2,
+              });
+            }, 50);
+          }),
+      );
+
+      (mockStore.embed as ReturnType<typeof mock>).mockImplementation(
+        () =>
+          new Promise((resolve) => {
+            executionLog.push("embed-start");
+            setTimeout(() => {
+              executionLog.push("embed-end");
+              resolve({
+                docsProcessed: 2,
+                chunksEmbedded: 10,
+                errors: 0,
+                durationMs: 500,
+              });
+            }, 50);
+          }),
+      );
+
+      // Fire both concurrently
+      const [updateResult, embedResult] = await Promise.all([
+        update(),
+        embed(),
+      ]);
+
+      expect(updateResult.indexed).toBe(5);
+      expect(embedResult.docsProcessed).toBe(2);
+
+      // They should have run sequentially: update fully completes before embed starts
+      expect(executionLog).toEqual([
+        "update-start",
+        "update-end",
+        "embed-start",
+        "embed-end",
+      ]);
+    });
+
+    test("lock releases after an error so subsequent calls still work", async () => {
+      await initStore("/tmp/test.sqlite");
+
+      (mockStore.update as ReturnType<typeof mock>).mockImplementationOnce(
+        () => Promise.reject(new Error("first call fails")),
+      );
+
+      // First call fails
+      await expect(update()).rejects.toThrow("first call fails");
+
+      // Second call should still work (lock released)
+      const result = await update();
+      expect(result.indexed).toBe(5);
+    });
+  });
+
   // ─── resetStore() ─────────────────────────────────────────
 
   describe("resetStore()", () => {

--- a/packages/qmd-client/index.ts
+++ b/packages/qmd-client/index.ts
@@ -28,6 +28,7 @@ export type {
 // ── Singleton ──────────────────────────────────────────────────────────────
 
 let store: QMDStore | null = null;
+let operationLock: Promise<unknown> = Promise.resolve();
 
 const DEFAULT_DB_PATH = "/app/db/qmd.sqlite";
 
@@ -38,6 +39,17 @@ function requireStore(): QMDStore {
     );
   }
   return store;
+}
+
+/**
+ * Acquire the operation lock, ensuring update() and embed() never run
+ * concurrently (prevents SQLite lock contention).
+ */
+function withLock<T>(fn: () => Promise<T>): Promise<T> {
+  const next = operationLock.then(fn, fn);
+  // Keep the chain going regardless of success/failure
+  operationLock = next.catch(() => {});
+  return next;
 }
 
 // ── Exported Functions ─────────────────────────────────────────────────────
@@ -90,15 +102,15 @@ export async function closeStore(): Promise<void> {
  * Scan the filesystem and ingest content changes into the index.
  * Does NOT generate vector embeddings — call embed() separately.
  */
-export async function update(): Promise<UpdateResult> {
-  return requireStore().update();
+export function update(): Promise<UpdateResult> {
+  return withLock(() => requireStore().update());
 }
 
 /**
  * Generate vector embeddings for documents that need them.
  */
-export async function embed(): Promise<EmbedResult> {
-  return requireStore().embed();
+export function embed(): Promise<EmbedResult> {
+  return withLock(() => requireStore().embed());
 }
 
 /**
@@ -142,4 +154,5 @@ export async function addContext(
  */
 export function resetStore(): void {
   store = null;
+  operationLock = Promise.resolve();
 }


### PR DESCRIPTION
Closes #14

### Summary
- Added a promise-based concurrency lock (`withLock()`) to `qmd-client` that serializes `update()` and `embed()` calls, preventing SQLite lock contention
- Lock properly releases on both success and failure so subsequent operations are never blocked
- Added tests verifying sequential execution of concurrent calls and lock recovery after errors
- All existing tests continue to pass; `bun typecheck` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)