### PR TITLE
feat(core-api): add periodic embed interval (QMD2-004)

### DIFF
--- a/apps/core-api/src/embedder.test.ts
+++ b/apps/core-api/src/embedder.test.ts
@@ -1,0 +1,107 @@
+import { test, expect, beforeEach, afterEach, jest } from "bun:test";
+import { startEmbedInterval } from "./embedder";
+import type { EmbedResult } from "@kore/qmd-client";
+import type { EmbedderHandle } from "./embedder";
+
+const MOCK_EMBED_RESULT: EmbedResult = {
+  docsProcessed: 2,
+  chunksEmbedded: 10,
+  errors: 0,
+  durationMs: 500,
+};
+
+let handle: EmbedderHandle | null = null;
+
+afterEach(() => {
+  handle?.stop();
+  handle = null;
+});
+
+test("calls embedFn after the interval fires", async () => {
+  let embedCalls = 0;
+  const mockEmbed = async (): Promise<EmbedResult> => {
+    embedCalls++;
+    return MOCK_EMBED_RESULT;
+  };
+
+  handle = startEmbedInterval({ intervalMs: 50, embedFn: mockEmbed });
+
+  // Wait for at least one interval tick
+  await new Promise((r) => setTimeout(r, 120));
+
+  expect(embedCalls).toBeGreaterThanOrEqual(1);
+});
+
+test("does not call embedFn before the interval fires", async () => {
+  let embedCalls = 0;
+  const mockEmbed = async (): Promise<EmbedResult> => {
+    embedCalls++;
+    return MOCK_EMBED_RESULT;
+  };
+
+  handle = startEmbedInterval({ intervalMs: 500, embedFn: mockEmbed });
+
+  // Check immediately — should not have fired yet
+  await new Promise((r) => setTimeout(r, 50));
+  expect(embedCalls).toBe(0);
+});
+
+test("catches errors without stopping the interval", async () => {
+  let embedCalls = 0;
+  const mockEmbed = async (): Promise<EmbedResult> => {
+    embedCalls++;
+    if (embedCalls === 1) {
+      throw new Error("model load failed");
+    }
+    return MOCK_EMBED_RESULT;
+  };
+
+  handle = startEmbedInterval({ intervalMs: 50, embedFn: mockEmbed });
+
+  // Wait for multiple interval ticks
+  await new Promise((r) => setTimeout(r, 180));
+
+  // Should have been called multiple times despite the first error
+  expect(embedCalls).toBeGreaterThanOrEqual(2);
+});
+
+test("stop() prevents further embed calls", async () => {
+  let embedCalls = 0;
+  const mockEmbed = async (): Promise<EmbedResult> => {
+    embedCalls++;
+    return MOCK_EMBED_RESULT;
+  };
+
+  handle = startEmbedInterval({ intervalMs: 50, embedFn: mockEmbed });
+  handle.stop();
+  handle = null;
+
+  // Wait past the interval
+  await new Promise((r) => setTimeout(r, 150));
+
+  expect(embedCalls).toBe(0);
+});
+
+test("reads KORE_EMBED_INTERVAL_MS from env when intervalMs not provided", async () => {
+  const originalEnv = process.env.KORE_EMBED_INTERVAL_MS;
+  let embedCalls = 0;
+  const mockEmbed = async (): Promise<EmbedResult> => {
+    embedCalls++;
+    return MOCK_EMBED_RESULT;
+  };
+
+  try {
+    process.env.KORE_EMBED_INTERVAL_MS = "50";
+    handle = startEmbedInterval({ embedFn: mockEmbed });
+
+    await new Promise((r) => setTimeout(r, 120));
+
+    expect(embedCalls).toBeGreaterThanOrEqual(1);
+  } finally {
+    if (originalEnv === undefined) {
+      delete process.env.KORE_EMBED_INTERVAL_MS;
+    } else {
+      process.env.KORE_EMBED_INTERVAL_MS = originalEnv;
+    }
+  }
+});

--- a/apps/core-api/src/embedder.ts
+++ b/apps/core-api/src/embedder.ts
@@ -1,0 +1,46 @@
+import { embed } from "@kore/qmd-client";
+
+const DEFAULT_INTERVAL_MS = 600_000; // 10 minutes
+
+export interface EmbedderDeps {
+  intervalMs?: number;
+  embedFn?: typeof embed;
+}
+
+export interface EmbedderHandle {
+  stop: () => void;
+}
+
+/**
+ * Start a periodic interval that calls `qmdClient.embed()` to generate
+ * vector embeddings for documents that need them.
+ *
+ * If `embed()` fires while another operation is running, the concurrency
+ * lock in qmd-client will serialize the calls automatically.
+ *
+ * Errors are logged but never crash the interval.
+ */
+export function startEmbedInterval(deps?: EmbedderDeps): EmbedderHandle {
+  const intervalMs = deps?.intervalMs
+    ?? (process.env.KORE_EMBED_INTERVAL_MS
+      ? Number(process.env.KORE_EMBED_INTERVAL_MS)
+      : DEFAULT_INTERVAL_MS);
+  const embedFn = deps?.embedFn ?? embed;
+
+  const handle = setInterval(async () => {
+    try {
+      const result = await embedFn();
+      console.log(
+        `Embedder: embed complete (docs: ${result.docsProcessed}, chunks: ${result.chunksEmbedded})`,
+      );
+    } catch (err) {
+      console.error("Embedder: embed error (non-fatal):", err);
+    }
+  }, intervalMs);
+
+  return {
+    stop() {
+      clearInterval(handle);
+    },
+  };
+}

--- a/apps/core-api/src/index.ts
+++ b/apps/core-api/src/index.ts
@@ -4,6 +4,7 @@ import { QueueRepository } from "./queue";
 import { resolveDataPath, resolveQueueDbPath } from "./config";
 import { startWorker } from "./worker";
 import { startWatcher } from "./watcher";
+import { startEmbedInterval } from "./embedder";
 import { MemoryIndex } from "./memory-index";
 import { EventDispatcher } from "./event-dispatcher";
 import * as qmdClient from "@kore/qmd-client";
@@ -93,11 +94,15 @@ console.log("Kore extraction worker started (polling every 5s)");
 const watcher = startWatcher({ dataPath });
 console.log("Kore file watcher started (watching for .md changes)");
 
+const embedder = startEmbedInterval();
+console.log("Kore embed interval started");
+
 // ── Graceful shutdown ───────────────────────────────────────────────────
 
 async function shutdown() {
   console.log("Shutting down...");
   watcher.stop();
+  embedder.stop();
   worker.stop();
   await qmdClient.closeStore();
   console.log("QMD store closed");


### PR DESCRIPTION
Closes #15

### Summary
- Adds `startEmbedInterval()` in `apps/core-api/src/embedder.ts` — a `setInterval` that calls `qmdClient.embed()` every 10 minutes (configurable via `KORE_EMBED_INTERVAL_MS` env var)
- Errors are caught and logged without crashing the interval; concurrency is handled by the existing lock in qmd-client
- Interval is started in `index.ts` alongside watcher/worker and cleared during graceful shutdown
- 5 unit tests covering: interval fires, no premature calls, error resilience, stop behavior, env var config

🤖 Generated with [Claude Code](https://claude.com/claude-code)