### PR TITLE
feat: US-016: Upgrade health endpoint to use typed QMD status (QMD2-005)

### DIFF
--- a/apps/core-api/README.md
+++ b/apps/core-api/README.md
@@ -125,6 +125,22 @@ All endpoints except `/health` require `Authorization: Bearer <KORE_API_KEY>`.
 | `DELETE` | `/api/v1/memory/:id` | Yes | Delete a memory file by its frontmatter `id` |
 | `PUT` | `/api/v1/memory/:id` | Yes | Overwrite an existing memory file with updated content |
 
+### `GET /api/v1/health` response
+
+```json
+{
+  "status": "ok",
+  "version": "1.0.0",
+  "qmd": {
+    "status": "ok",          // "ok" | "bootstrapping" | "unavailable"
+    "doc_count": 42,
+    "collections": 1,
+    "needs_embedding": 5
+  },
+  "queue_length": 0
+}
+```
+
 ### `POST /api/v1/ingest/raw` payload
 
 ```json

--- a/apps/core-api/src/app.test.ts
+++ b/apps/core-api/src/app.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { createApp, ensureDataDirectories } from "./app";
-import type { QmdHealthStatus } from "./app";
+import type { QmdHealthSummary } from "./app";
 import { QueueRepository } from "./queue";
 import { join } from "node:path";
 import { mkdtemp, rm, readdir, readFile } from "node:fs/promises";
@@ -10,12 +10,12 @@ let tempDir: string;
 let queue: QueueRepository;
 let dbPath: string;
 
-function makeApp(overrides?: { apiKey?: string; qmdStatus?: () => Promise<QmdHealthStatus> }) {
+function makeApp(overrides?: { apiKey?: string; qmdStatus?: () => Promise<QmdHealthSummary> }) {
   process.env.KORE_API_KEY = overrides?.apiKey ?? "test-key";
   return createApp({
     queue,
     dataPath: tempDir,
-    qmdStatus: overrides?.qmdStatus ?? (async () => ({ status: "ready" as const })),
+    qmdStatus: overrides?.qmdStatus ?? (async () => ({ status: "ok" as const })),
   });
 }
 
@@ -69,7 +69,7 @@ describe("GET /api/v1/health", () => {
     expect(body).toEqual({
       status: "ok",
       version: "1.0.0",
-      qmd: { status: "ready" },
+      qmd: { status: "ok" },
       queue_length: 0,
     });
   });
@@ -81,20 +81,19 @@ describe("GET /api/v1/health", () => {
     expect(body.qmd.status).toBe("unavailable");
   });
 
-  test("reflects qmd bootstrapping status with index data", async () => {
-    const mockIndex = {
-      totalDocuments: 0,
-      needsEmbedding: 0,
-      hasVectorIndex: false,
-      collections: [],
+  test("reflects qmd bootstrapping status with flattened fields", async () => {
+    const mockSummary = {
+      status: "bootstrapping" as const,
+      doc_count: 5,
+      collections: 1,
+      needs_embedding: 2,
     };
     const app = makeApp({
-      qmdStatus: async () => ({ status: "bootstrapping" as const, index: mockIndex }),
+      qmdStatus: async () => mockSummary,
     });
     const res = await app.handle(new Request("http://localhost/api/v1/health"));
     const body = await res.json();
-    expect(body.qmd.status).toBe("bootstrapping");
-    expect(body.qmd.index).toEqual(mockIndex);
+    expect(body.qmd).toEqual(mockSummary);
   });
 
   test("does not require auth", async () => {

--- a/apps/core-api/src/app.ts
+++ b/apps/core-api/src/app.ts
@@ -5,7 +5,6 @@ import { z } from "zod";
 import { randomUUID } from "crypto";
 import { BaseFrontmatterSchema, MemoryTypeEnum } from "@kore/shared-types";
 import type { BaseFrontmatter } from "@kore/shared-types";
-import type { IndexStatus } from "@kore/qmd-client";
 import { QueueRepository } from "./queue";
 import { slugify } from "./slugify";
 import { renderMarkdown } from "./markdown";
@@ -149,16 +148,18 @@ interface MemoryFull extends MemorySummary {
 
 // ─── QMD Health Status ───────────────────────────────────────────────
 
-export interface QmdHealthStatus {
-  status: "ready" | "bootstrapping" | "unavailable";
-  index?: IndexStatus;
+export interface QmdHealthSummary {
+  status: "ok" | "bootstrapping" | "unavailable";
+  doc_count?: number;
+  collections?: number;
+  needs_embedding?: number;
 }
 
 // ─── App Factory ─────────────────────────────────────────────────────
 
 export interface AppDeps {
   queue?: QueueRepository;
-  qmdStatus?: () => Promise<QmdHealthStatus>;
+  qmdStatus?: () => Promise<QmdHealthSummary>;
   dataPath?: string;
   memoryIndex?: MemoryIndex;
   eventDispatcher?: EventDispatcher;

--- a/apps/core-api/src/index.ts
+++ b/apps/core-api/src/index.ts
@@ -1,5 +1,5 @@
 import { createApp, ensureDataDirectories } from "./app";
-import type { QmdHealthStatus } from "./app";
+import type { QmdHealthSummary } from "./app";
 import { QueueRepository } from "./queue";
 import { resolveDataPath, resolveQueueDbPath } from "./config";
 import { startWorker } from "./worker";
@@ -30,12 +30,16 @@ try {
 
 let bootstrapping = false;
 
-const qmdStatus = async (): Promise<QmdHealthStatus> => {
+const qmdStatus = async (): Promise<QmdHealthSummary> => {
   try {
     const index = await qmdClient.getStatus();
+    const health = await qmdClient.getIndexHealth();
+    
     return {
-      status: bootstrapping ? "bootstrapping" : "ready",
-      index,
+      status: bootstrapping ? "bootstrapping" : "ok",
+      doc_count: index.totalDocuments,
+      collections: index.collections?.length || 0,
+      needs_embedding: health.needsEmbedding,
     };
   } catch {
     return { status: "unavailable" };

--- a/apps/core-api/src/memory.test.ts
+++ b/apps/core-api/src/memory.test.ts
@@ -21,7 +21,7 @@ function makeApp() {
   return createApp({
     queue,
     dataPath: tempDir,
-    qmdStatus: async () => ({ status: "ready" as const }),
+    qmdStatus: async () => ({ status: "ok" as const }),
     memoryIndex,
     eventDispatcher,
   });


### PR DESCRIPTION
Closes #16

### Summary
- Updated `QmdHealthStatus` to a flattened `QmdHealthSummary` shape
- Updated `qmdStatus` returning function in `index.ts` to fetch and use `getIndexHealth()`
- Fixed failing unit tests in `app.test.ts` and `memory.test.ts`
- Updated health endpoint API schema in `apps/core-api/README.md`