### PR TITLE
feat: Simplify Dockerfile and docker-compose for SDK-based setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,10 @@ OLLAMA_MODEL=qwen2.5:7b
 
 # Docker-specific: override OLLAMA_BASE_URL for container→host connectivity
 # OLLAMA_BASE_URL=http://host.docker.internal:11434
+
+# QMD model cache path — GGUF models (~2GB+) are downloaded on first embed/search.
+# Mount a persistent volume to avoid re-downloading on every container restart.
+QMD_CACHE_PATH=~/.kore/qmd-cache
+
+# Interval (ms) between periodic embed() calls for vector embeddings (default: 5 min)
+KORE_EMBED_INTERVAL_MS=300000

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,26 +34,15 @@ FROM oven/bun:1.1.8-debian AS runner
 
 WORKDIR /app
 
-# Install Spatialite and QMD CLI dependencies
+# Install Spatialite runtime dependency
 RUN apt-get update && apt-get install -y \
     libsqlite3-mod-spatialite \
     && rm -rf /var/lib/apt/lists/*
-
-# Symlink bun to node since qmd expects node in its shebang
-RUN ln -s /usr/local/bin/bun /usr/local/bin/node
 
 # Ensure the container runs as a non-root user to avoid permission issues
 # with bind mounts on the host (e.g. SQLite DB and Markdown files)
 RUN chown -R bun:bun /app
 USER bun
-
-# Add bun's global bin directory to PATH for the bun user
-ENV BUN_INSTALL="/home/bun/.bun"
-ENV BUN_INSTALL_BIN="${BUN_INSTALL}/bin"
-ENV PATH="${BUN_INSTALL_BIN}:${PATH}"
-
-# Install QMD CLI globally as the bun user so it is accessible and in the PATH
-RUN bun install -g @tobilu/qmd
 
 # Copy built node_modules and source from builder stage
 COPY --from=builder --chown=bun:bun /app/node_modules ./node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,12 @@ services:
       - KORE_API_KEY=${KORE_API_KEY}
       - OLLAMA_BASE_URL=${OLLAMA_BASE_URL:-http://host.docker.internal:11434}
       - OLLAMA_MODEL=${OLLAMA_MODEL:-qwen2.5:7b}
+      - KORE_QMD_DB_PATH=/app/db/qmd.sqlite
+      - KORE_EMBED_INTERVAL_MS=${KORE_EMBED_INTERVAL_MS:-300000}
     volumes:
       - ${KORE_DATA_PATH:-~/.kore/data}:/app/data
       - ${KORE_DB_PATH:-~/.kore/db}:/app/db
-      - ${QMD_CONFIG_PATH:-~/.kore/qmd-config}:/home/bun/.config/qmd
+      - ${QMD_CACHE_PATH:-~/.kore/qmd-cache}:/home/bun/.cache/qmd
     command: ["bun", "run", "apps/core-api/src/index.ts"]
     restart: unless-stopped
     extra_hosts:
@@ -33,7 +35,6 @@ services:
     volumes:
       - ${KORE_DATA_PATH:-~/.kore/data}:/app/data
       - ${KORE_DB_PATH:-~/.kore/db}:/app/db
-      - ${QMD_CONFIG_PATH:-~/.kore/qmd-config}:/home/bun/.config/qmd
     command: ["bun", "run", "apps/core-api/src/worker-entry.ts"]
     restart: unless-stopped
     extra_hosts:

--- a/docs/qmd-2.0/assessment.md
+++ b/docs/qmd-2.0/assessment.md
@@ -116,7 +116,7 @@ We should completely overhaul `packages/qmd-client` to wrap the new SDK.
    - Wire `store.getStatus()` into the health endpoint (currently using `qmd status` parse).
 4. **Update Tests:** Refactor `packages/qmd-client/index.test.ts` to mock the QMD store object rather than mocking `Bun.spawn`.
 
-## 6. Docker & Infrastructure Considerations
+## 6. Docker & Infrastructure Considerations ✅ Implemented
 
 Migrating to the native SDK will significantly streamline our Docker setup, but it introduces a critical requirement regarding caching.
 


### PR DESCRIPTION
Closes #17

### Summary
- Removed global QMD CLI installation (`bun install -g @tobilu/qmd`), node symlink, and `BUN_INSTALL`/`BUN_INSTALL_BIN` env vars from Dockerfile runner stage
- Replaced `QMD_CONFIG_PATH` volume mount with `QMD_CACHE_PATH` volume on `core-api` for persistent GGUF model cache (~2GB+)
- Removed QMD config volume from `notification-worker` service
- Added `KORE_QMD_DB_PATH` and `KORE_EMBED_INTERVAL_MS` environment variables to `core-api`
- Documented `QMD_CACHE_PATH` and `KORE_EMBED_INTERVAL_MS` in `.env.example`
- Marked Docker section in `docs/qmd-2.0/assessment.md` as implemented

**Note:** Docker build has a pre-existing failure on `main` (`better-sqlite3` native addon compilation). This PR does not introduce or fix that issue.