### PR TITLE
feat: QMD2-007 Expose /api/v1/search endpoint

### DIFF
--- a/apps/core-api/README.md
+++ b/apps/core-api/README.md
@@ -119,6 +119,7 @@ All endpoints except `/health` require `Authorization: Bearer <KORE_API_KEY>`.
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | `GET` | `/api/v1/health` | No | Health check — returns server status, QMD status, and current queue length |
+| `POST` | `/api/v1/search` | Yes | Hybrid semantic search over indexed memories — returns ranked results |
 | `POST` | `/api/v1/ingest/raw` | Yes | Queue raw text for async LLM extraction → returns `202` with `task_id` |
 | `GET` | `/api/v1/task/:id` | Yes | Check extraction task status (`queued`, `processing`, `completed`, `failed`) |
 | `POST` | `/api/v1/ingest/structured` | Yes | Directly write a fully-formed memory file, bypassing LLM → returns `200` with `file_path` |
@@ -139,6 +140,47 @@ All endpoints except `/health` require `Authorization: Bearer <KORE_API_KEY>`.
   },
   "queue_length": 0
 }
+```
+
+### `POST /api/v1/search` payload
+
+```json
+{
+  "query": "meeting notes from last week",
+  "intent": "personal knowledge base containing notes, contacts, and bookmarks",
+  "limit": 10,
+  "collection": "memories"
+}
+```
+
+- `query` (required) — the search string
+- `intent` (optional) — domain hint for reranking; defaults to `"personal knowledge base containing notes, contacts, and bookmarks"`
+- `limit` (optional) — max results, capped at 20, defaults to 10
+- `collection` (optional) — restrict search to a named collection
+
+#### Response `200`
+
+```json
+[
+  {
+    "path": "/app/data/notes/meeting.md",
+    "title": "Team Meeting Notes",
+    "snippet": "Discussed roadmap priorities for Q2",
+    "score": 0.92,
+    "collection": "memories"
+  }
+]
+```
+
+Returns `503 { "error": "Search index not available" }` if the QMD store is not initialized.
+
+#### Example
+
+```bash
+curl -X POST http://localhost:3000/api/v1/search \
+  -H "Authorization: Bearer $KORE_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"query": "ramen spots in Tokyo"}'
 ```
 
 ### `POST /api/v1/ingest/raw` payload

--- a/apps/core-api/src/app.test.ts
+++ b/apps/core-api/src/app.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect, beforeAll, afterAll, beforeEach, afterEach } from "bun:test";
 import { createApp, ensureDataDirectories } from "./app";
 import type { QmdHealthSummary } from "./app";
+import type { HybridQueryResult, HybridQueryOptions } from "@kore/qmd-client";
 import { QueueRepository } from "./queue";
 import { join } from "node:path";
 import { mkdtemp, rm, readdir, readFile } from "node:fs/promises";
@@ -10,12 +11,17 @@ let tempDir: string;
 let queue: QueueRepository;
 let dbPath: string;
 
-function makeApp(overrides?: { apiKey?: string; qmdStatus?: () => Promise<QmdHealthSummary> }) {
+function makeApp(overrides?: {
+  apiKey?: string;
+  qmdStatus?: () => Promise<QmdHealthSummary>;
+  searchFn?: (query: string, options?: HybridQueryOptions) => Promise<HybridQueryResult[]>;
+}) {
   process.env.KORE_API_KEY = overrides?.apiKey ?? "test-key";
   return createApp({
     queue,
     dataPath: tempDir,
     qmdStatus: overrides?.qmdStatus ?? (async () => ({ status: "ok" as const })),
+    searchFn: overrides?.searchFn,
   });
 }
 
@@ -331,5 +337,115 @@ describe("POST /api/v1/ingest/structured", () => {
       }),
     });
     expect(res.status).toBe(400);
+  });
+});
+
+// ─── POST /api/v1/search ─────────────────────────────────────────────
+
+describe("POST /api/v1/search", () => {
+  const mockResults: HybridQueryResult[] = [
+    {
+      file: "/app/data/notes/meeting.md",
+      displayPath: "qmd://memories/notes/meeting.md",
+      title: "Team Meeting Notes",
+      body: "Full body content...",
+      bestChunk: "Discussed roadmap priorities for Q2",
+      bestChunkPos: 0,
+      score: 0.92,
+      context: null,
+      docid: "abc123",
+    },
+    {
+      file: "/app/data/people/alice.md",
+      displayPath: "qmd://memories/people/alice.md",
+      title: "Alice Smith",
+      body: "Contact details...",
+      bestChunk: "Product manager at Acme Corp",
+      bestChunkPos: 0,
+      score: 0.78,
+      context: null,
+      docid: "def456",
+    },
+  ];
+
+  test("returns mapped search results on success", async () => {
+    const app = makeApp({
+      searchFn: async () => mockResults,
+    });
+    const res = await req(app, "/api/v1/search", {
+      method: "POST",
+      body: JSON.stringify({ query: "meeting notes" }),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual([
+      {
+        path: "/app/data/notes/meeting.md",
+        title: "Team Meeting Notes",
+        snippet: "Discussed roadmap priorities for Q2",
+        score: 0.92,
+        collection: "memories",
+      },
+      {
+        path: "/app/data/people/alice.md",
+        title: "Alice Smith",
+        snippet: "Product manager at Acme Corp",
+        score: 0.78,
+        collection: "memories",
+      },
+    ]);
+  });
+
+  test("returns 400 when query is missing", async () => {
+    const app = makeApp({
+      searchFn: async () => [],
+    });
+    const res = await req(app, "/api/v1/search", {
+      method: "POST",
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.code).toBe("VALIDATION_ERROR");
+  });
+
+  test("returns 503 when store is not initialized (no searchFn)", async () => {
+    const app = makeApp(); // no searchFn provided
+    const res = await req(app, "/api/v1/search", {
+      method: "POST",
+      body: JSON.stringify({ query: "test" }),
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("Search index not available");
+  });
+
+  test("returns 503 when searchFn throws", async () => {
+    const app = makeApp({
+      searchFn: async () => {
+        throw new Error("Store not ready");
+      },
+    });
+    const res = await req(app, "/api/v1/search", {
+      method: "POST",
+      body: JSON.stringify({ query: "test" }),
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("Search index not available");
+  });
+
+  test("requires bearer auth", async () => {
+    const app = makeApp({
+      searchFn: async () => [],
+    });
+    const res = await app.handle(
+      new Request("http://localhost/api/v1/search", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ query: "test" }),
+      })
+    );
+    expect(res.status).toBe(401);
   });
 });

--- a/apps/core-api/src/app.ts
+++ b/apps/core-api/src/app.ts
@@ -13,6 +13,7 @@ import { join } from "node:path";
 import { resolveDataPath } from "./config";
 import { MemoryIndex } from "./memory-index";
 import { EventDispatcher } from "./event-dispatcher";
+import type { HybridQueryResult, HybridQueryOptions } from "@kore/qmd-client";
 
 // ─── Zod Schemas for request validation ─────────────────────────────
 
@@ -30,6 +31,16 @@ const StructuredIngestPayload = z.object({
     frontmatter: BaseFrontmatterSchema.omit({ id: true }),
   }),
 });
+
+const SearchRequestPayload = z.object({
+  query: z.string().min(1, "query is required"),
+  intent: z.string().optional(),
+  limit: z.number().int().positive().optional(),
+  collection: z.string().optional(),
+});
+
+const DEFAULT_SEARCH_INTENT =
+  "personal knowledge base containing notes, contacts, and bookmarks";
 
 // ─── Helpers ─────────────────────────────────────────────────────────
 
@@ -160,6 +171,7 @@ export interface QmdHealthSummary {
 export interface AppDeps {
   queue?: QueueRepository;
   qmdStatus?: () => Promise<QmdHealthSummary>;
+  searchFn?: (query: string, options?: HybridQueryOptions) => Promise<HybridQueryResult[]>;
   dataPath?: string;
   memoryIndex?: MemoryIndex;
   eventDispatcher?: EventDispatcher;
@@ -169,6 +181,7 @@ export function createApp(deps: AppDeps = {}) {
   const dataPath = deps.dataPath || resolveDataPath();
   const queue = deps.queue || new QueueRepository();
   const qmdStatus = deps.qmdStatus || (async () => ({ status: "unavailable" as const }));
+  const searchFn = deps.searchFn;
   const memoryIndex = deps.memoryIndex || new MemoryIndex();
   const eventDispatcher = deps.eventDispatcher || new EventDispatcher();
   const apiKey = process.env.KORE_API_KEY;
@@ -195,6 +208,48 @@ export function createApp(deps: AppDeps = {}) {
         queue_length: queue.getQueueLength(),
       };
     })
+    // ─── Search ───────────────────────────────────────────────────
+    .post("/api/v1/search", async ({ body, set }) => {
+      const result = SearchRequestPayload.safeParse(body);
+      if (!result.success) {
+        set.status = 400;
+        return {
+          error: result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join("; "),
+          code: "VALIDATION_ERROR",
+        };
+      }
+
+      if (!searchFn) {
+        set.status = 503;
+        return { error: "Search index not available" };
+      }
+
+      const { query, intent, limit, collection } = result.data;
+      const cappedLimit = Math.min(limit ?? 10, 20);
+
+      try {
+        const results = await searchFn(query, {
+          intent: intent ?? DEFAULT_SEARCH_INTENT,
+          limit: cappedLimit,
+          collection,
+        });
+
+        return results.map((r) => {
+          // Extract collection name from displayPath (qmd://collection-name/...)
+          const dpMatch = r.displayPath?.match(/^qmd:\/\/([^/]+)/);
+          return {
+            path: r.file,
+            title: r.title,
+            snippet: r.bestChunk,
+            score: r.score,
+            collection: dpMatch?.[1] ?? null,
+          };
+        });
+      } catch {
+        set.status = 503;
+        return { error: "Search index not available" };
+      }
+    }, { body: t.Any() })
     // ─── Ingest Raw ───────────────────────────────────────────────
     .post("/api/v1/ingest/raw", async ({ body, set }) => {
       const result = RawIngestPayload.safeParse(body);

--- a/packages/qmd-client/index.ts
+++ b/packages/qmd-client/index.ts
@@ -14,6 +14,8 @@ import {
   type IndexStatus,
   type IndexHealthInfo,
   type CollectionConfig,
+  type HybridQueryResult,
+  type HybridQueryOptions,
 } from "@tobilu/qmd";
 
 // Re-export SDK types for downstream consumers
@@ -23,6 +25,8 @@ export type {
   EmbedResult,
   IndexStatus,
   IndexHealthInfo,
+  HybridQueryResult,
+  HybridQueryOptions,
 };
 
 // ── Singleton ──────────────────────────────────────────────────────────────
@@ -146,6 +150,17 @@ export async function addContext(
   contextText: string,
 ): Promise<boolean> {
   return requireStore().addContext(collectionName, pathPrefix, contextText);
+}
+
+/**
+ * Hybrid search: BM25 + vector + query expansion + LLM reranking.
+ * Returns ranked results with snippets and scores.
+ */
+export function search(
+  query: string,
+  options?: HybridQueryOptions,
+): Promise<HybridQueryResult[]> {
+  return withLock(() => requireStore().query(query, options));
 }
 
 /**


### PR DESCRIPTION
Closes #18

### Summary
Adds `POST /api/v1/search` — a hybrid semantic search endpoint (BM25 + vector + LLM reranking) powered by the QMD SDK.

**Changes:**
- `packages/qmd-client/index.ts`: Added `search()` wrapper around `store.query()` with concurrency lock
- `apps/core-api/src/app.ts`: Added search endpoint with zod validation, limit capping (max 20, default 10), default intent, and 503 fallback for uninitialized store
- `apps/core-api/src/app.test.ts`: 5 new tests covering success response shape, missing query (400), uninitialized store (503), search error (503), and auth requirement (401)
- `apps/core-api/README.md`: Documented search endpoint with request/response schema and example curl

**All 96 tests pass.**