### PR TITLE
feat: Update documentation and add compiled binary build scripts (NHP-004)

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ kore/
 - [Bun](https://bun.sh/) — `curl -fsSL https://bun.sh/install | bash`
 - [Ollama](https://ollama.ai/) — install, then `ollama pull qwen2.5:7b`
 - [QMD](https://github.com/tobilu/qmd) — installed and on `$PATH`
+- **Spatialite** (required for geospatial memory features):
+  - macOS: `brew install spatialite-tools`
+  - Linux (Debian/Ubuntu): `apt-get install libsqlite3-mod-spatialite`
 
 ### 1. Install dependencies
 
@@ -92,30 +95,32 @@ bun install
 cp .env.example .env
 ```
 
-Edit `.env`:
+Edit `.env`. The primary configuration variable is `KORE_HOME`, which sets the base directory for all Kore data (database files, notes storage). It defaults to `~/.kore` if not set.
 
 ```
-KORE_DATA_PATH=~/.kore/data
+KORE_HOME=~/.kore
 KORE_API_KEY=your-secret-key-here
 OLLAMA_BASE_URL=http://localhost:11434
 OLLAMA_MODEL=qwen2.5:7b
 ```
 
-### 3. Register your data directory with QMD (one-time)
+| Variable | Default | Description |
+|---|---|---|
+| `KORE_HOME` | `~/.kore` | Base directory for all Kore data (SQLite queue, notes, QMD cache) |
+| `KORE_API_KEY` | *(required)* | Bearer token for API authentication |
+| `OLLAMA_BASE_URL` | `http://localhost:11434` | Ollama server URL |
+| `OLLAMA_MODEL` | `qwen2.5:7b` | Model used for LLM extraction |
+| `QMD_CACHE_PATH` | `~/.kore/qmd-cache` | Cache directory for QMD GGUF embedding models |
+
+### 3. Start the API
 
 ```sh
-qmd collection add ~/.kore/data --name kore-memory
+bun run start
 ```
 
-### 4. Start the API
+The API is now running at `http://localhost:3000`. Logs appear directly in your terminal.
 
-```sh
-bun run --filter @kore/core-api start
-```
-
-The API is now running at `http://localhost:3000`.
-
-### 5. Install and use the CLI
+### 4. Install and use the CLI
 
 ```sh
 # Install globally
@@ -124,7 +129,7 @@ bun install -g ./apps/cli
 # Check connectivity
 kore health
 
-# Send your first memory (coming in US-002)
+# Send your first memory
 kore ingest note.md
 ```
 
@@ -166,14 +171,6 @@ bun add <package> --filter @kore/core-api
 
 Kore runs as a single Bun process — no Docker or process orchestration required. The API server, extraction worker, file watcher, and embedder all run together via `apps/core-api/src/index.ts`.
 
-### Prerequisites
-
-- [Bun](https://bun.sh/) installed
-- [Ollama](https://ollama.ai/) running locally with a model pulled (e.g., `ollama pull qwen2.5:7b`)
-- [QMD](https://github.com/tobilu/qmd) installed and on `$PATH`
-
-### Start the full stack
-
 ```sh
 # Production
 bun run start
@@ -182,7 +179,22 @@ bun run start
 bun run dev
 ```
 
-The API is available at `http://localhost:3000`.
+The API is available at `http://localhost:3000`. All log output (startup, worker activity, watcher events) appears directly in your terminal.
+
+## Building Standalone Binaries
+
+You can compile the API server and CLI into self-contained executables using Bun's `--compile` flag:
+
+```sh
+# Build both binaries
+bun run build:bin
+
+# Or build individually
+bun run --cwd apps/core-api build:bin   # → apps/core-api/bin/kore-server
+bun run --cwd apps/cli build:bin        # → apps/cli/bin/kore
+```
+
+> **Note on `node-llama-cpp`:** QMD depends on `node-llama-cpp`, which ships pre-built native `.node` binaries for each platform (e.g., `@node-llama-cpp/mac-arm64-metal`). These native addons are **not bundleable** into a single `bun build --compile` executable. The compiled `kore-server` binary falls back gracefully — QMD's embedding features will be unavailable unless you run via `bun run start` (which resolves the native addons through `node_modules`). For production deployments, `bun run start` is the recommended approach. **Spatialite (`mod_spatialite`) must also be installed on the host — it cannot be bundled.**
 
 ---
 

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "start": "bun run src/index.ts",
-    "test": "bun test"
+    "test": "bun test",
+    "build:bin": "bun build --compile src/index.ts --outfile bin/kore"
   },
   "dependencies": {
     "cli-table3": "^0.6.5",

--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "bun run src/index.ts",
     "dev": "bun --hot run src/index.ts",
-    "test": "bun test"
+    "test": "bun test",
+    "build:bin": "bun build --compile src/index.ts --outfile bin/kore-server"
   },
   "dependencies": {
     "@kore/llm-extractor": "workspace:*",

--- a/docs/architecture/architecture.md
+++ b/docs/architecture/architecture.md
@@ -44,7 +44,7 @@ Following the established project constraints (Strict TypeScript, Bun, native-fi
     *   **File System:** For raw markdown files.
     *   **QMD (`@tobilu/qmd`):** For agentic hybrid search (BM25 + Vector + Reranking) running cleanly within the Node/Bun ecosystem.
 *   **LLM Integration:** **Vercel AI SDK** with `createOpenAI()` provider defaulting to a local **Ollama** instance (`http://localhost:11434/v1`, model `qwen2.5:7b`) for cost-efficient, privacy-first extraction. Cloud providers (OpenAI, Anthropic) can be configured as alternatives. QMD handles local GGUF embedding via Node LLAMA CPP. Plugins can run their own specialized LLM calls.
-*   **Infrastructure:** Native Bun process. The API, background workers, and QMD all run in a single `bun run apps/core-api/src/index.ts` process — no containers or orchestration required.
+*   **Infrastructure:** Native Bun single-process. The API server, extraction worker, file watcher, and QMD embedder all run together in a single `bun run start` (`apps/core-api/src/index.ts`) process — no Docker, containers, or process orchestration required. `KORE_HOME` (default: `~/.kore`) is the single environment variable controlling where all data is stored.
 
 ---
 

--- a/e2e/manual-testing.md
+++ b/e2e/manual-testing.md
@@ -4,10 +4,10 @@ Use this guide to validate the Kore ingestion and search pipeline step by step b
 
 ## Prerequisites
 
-Start the Docker stack:
+Start the API natively:
 ```sh
-docker compose up -d
-docker compose logs -f   # watch worker output in a separate terminal
+bun run start
+# Watch logs directly in this terminal — worker and watcher output appears here
 ```
 
 ---
@@ -79,7 +79,7 @@ Delete a specific memory:
 bun run apps/cli/src/index.ts delete <id> --force
 ```
 
-Stop the stack:
+Stop the server:
 ```sh
-docker compose down
+# Press Ctrl+C in the terminal running `bun run start`
 ```

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "start": "bun run apps/core-api/src/index.ts",
     "dev": "bun --hot run apps/core-api/src/index.ts",
     "test": "bun test --recursive",
-    "typecheck": "bunx tsc --noEmit --project tsconfig.json"
+    "typecheck": "bunx tsc --noEmit --project tsconfig.json",
+    "build:bin": "bun run --cwd apps/core-api build:bin && bun run --cwd apps/cli build:bin"
   },
   "workspaces": [
     "./packages/*",


### PR DESCRIPTION
Closes #40

### Summary
- Added Spatialite prerequisites to README for macOS (`brew install spatialite-tools`) and Linux (`apt-get install libsqlite3-mod-spatialite`)
- Updated Getting Started section to use `bun install` → configure `.env` → `bun run start` (no Docker)
- Documented `KORE_HOME` as the primary configuration variable with a full environment variable reference table
- Added `"build:bin"` scripts to `apps/core-api/package.json`, `apps/cli/package.json`, and root `package.json`
- Investigated `node-llama-cpp` under `bun build --compile`: native `.node` addons are not bundleable — documented the limitation and workaround in README
- Updated `e2e/manual-testing.md` to reference host terminal logs instead of `docker compose logs`
- Updated `docs/architecture/architecture.md` to explicitly reflect the single-process native host model with `KORE_HOME`
- Confirmed `bun run typecheck` exits with code 0