### PR TITLE
feat: RESET-002 — kore reset CLI command + e2e/README.md updates

### DIFF
--- a/apps/cli/src/commands/reset.ts
+++ b/apps/cli/src/commands/reset.ts
@@ -1,0 +1,48 @@
+import { apiFetch } from "../api.ts";
+
+interface ResetOpts {
+  force: boolean;
+}
+
+interface ResetResponse {
+  status: string;
+  deleted_memories: number;
+  deleted_tasks: number;
+}
+
+async function confirm(message: string): Promise<boolean> {
+  const enquirer = await import("enquirer");
+  return (enquirer.default as any).confirm({ name: "value", message });
+}
+
+export async function resetCommand(opts: ResetOpts): Promise<void> {
+  if (!opts.force) {
+    const yes = await confirm(
+      "This will permanently delete all memories, tasks, and the search index. Continue?"
+    );
+    if (!yes) {
+      process.stdout.write("Aborted.\n");
+      return;
+    }
+  }
+
+  const result = await apiFetch<ResetResponse>("/api/v1/memories", {
+    method: "DELETE",
+  });
+
+  if (!result.ok) {
+    if (result.status === 0) {
+      process.stderr.write(`Error: ${result.message}\n`);
+    } else {
+      process.stderr.write(
+        `Error: API error (${result.status}): ${result.message}\n`
+      );
+    }
+    process.exit(1);
+  }
+
+  const { deleted_memories, deleted_tasks } = result.data;
+  process.stdout.write(
+    `✓ Reset complete. Deleted ${deleted_memories} memories and ${deleted_tasks} tasks.\n`
+  );
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -9,6 +9,7 @@ import { listCommand } from "./commands/list.ts";
 import { showCommand } from "./commands/show.ts";
 import { deleteCommand } from "./commands/delete.ts";
 import { searchCommand } from "./commands/search.ts";
+import { resetCommand } from "./commands/reset.ts";
 
 // Read version from package.json
 const pkg = await import("../package.json", { with: { type: "json" } });
@@ -114,6 +115,15 @@ program
   .option("--json", "Output results as JSON", false)
   .action(async (query, opts) => {
     await searchCommand(query, opts);
+  });
+
+// ─── reset ──────────────────────────────────────────────────────────────────
+program
+  .command("reset")
+  .description("Delete all memories, tasks, and the search index")
+  .option("--force", "Skip confirmation prompt", false)
+  .action(async (opts) => {
+    await resetCommand(opts);
   });
 
 // Unknown commands: print error + help, exit 1

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -23,6 +23,8 @@ kore ingest e2e/dataset/tokyo-ramen.md --source "e2e/tokyo-ramen"
 
 **All dataset files at once:**
 ```sh
+# --wait is the default: blocks until each file's LLM extraction completes.
+# Use --no-wait to queue all files and return immediately.
 kore ingest e2e/dataset/*.md
 ```
 
@@ -63,6 +65,20 @@ kore search "where should I eat in Tokyo" --intent "personal travel and food boo
 Delete a specific memory:
 ```sh
 kore delete <id> --force
+```
+
+#### Resetting for a fresh test run
+
+To wipe all memories, the task queue, and the search index in one step:
+```sh
+kore reset --force
+```
+This deletes all `.md` files under `$KORE_HOME/data/`, clears all queue tasks, and reinitialises the QMD SQLite database. The server keeps running — no restart needed.
+
+After reset, confirm the slate is clean:
+```sh
+kore list   # should show 0 results
+kore health # queue_length should be 0
 ```
 
 Stop the server:


### PR DESCRIPTION
Closes #46

### Summary
- Added `kore reset` CLI command (`apps/cli/src/commands/reset.ts`) that calls `DELETE /api/v1/memories` to wipe all memories, tasks, and the search index in one step.
- Without `--force`, prompts for confirmation using enquirer (matching existing CLI conventions). With `--force`, skips the prompt for scripting use.
- On success, prints `✓ Reset complete. Deleted N memories and M tasks.`
- On API error or network failure, prints to stderr and exits with code 1.
- Updated `e2e/README.md`:
  - Added "Resetting for a fresh test run" subsection under `### 3. Cleanup` documenting `kore reset --force`.
  - Added `--wait` clarification comment to the multi-file ingest example.