### PR TITLE
feat: Worker memory.indexed emission + core-api startup wiring (PLUG-003)

### DIFF
--- a/apps/core-api/src/app.ts
+++ b/apps/core-api/src/app.ts
@@ -14,6 +14,7 @@ import { resolveDataPath, resolveQmdDbPath } from "./config";
 import * as qmdClient from "@kore/qmd-client";
 import { MemoryIndex } from "./memory-index";
 import { EventDispatcher } from "./event-dispatcher";
+import { deleteMemoryById } from "./delete-memory";
 import type { HybridQueryResult, SearchOptions } from "@kore/qmd-client";
 
 // ─── Zod Schemas for request validation ─────────────────────────────
@@ -403,37 +404,11 @@ export function createApp(deps: AppDeps = {}) {
     })
     // ─── Delete Memory ────────────────────────────────────────────
     .delete("/api/v1/memory/:id", async ({ params, set }) => {
-      const filePath = memoryIndex.get(params.id);
-      if (!filePath) {
+      const deleted = await deleteMemoryById(params.id, { memoryIndex, eventDispatcher });
+      if (!deleted) {
         set.status = 404;
         return { error: "Memory not found", code: "NOT_FOUND" };
       }
-
-      // Read frontmatter before deleting for the event payload
-      let frontmatter: Record<string, any> = {};
-      try {
-        const content = await readFile(filePath, "utf-8");
-        frontmatter = parseFrontmatter(content);
-      } catch {
-        // file may already be gone
-      }
-
-      try {
-        await unlink(filePath);
-      } catch {
-        set.status = 404;
-        return { error: "Memory not found", code: "NOT_FOUND" };
-      }
-
-      memoryIndex.delete(params.id);
-
-      await eventDispatcher.emit("memory.deleted", {
-        id: params.id,
-        filePath,
-        frontmatter,
-        timestamp: new Date().toISOString(),
-      });
-
       return { status: "deleted", id: params.id };
     })
     // ─── Update Memory ────────────────────────────────────────────

--- a/apps/core-api/src/delete-memory.ts
+++ b/apps/core-api/src/delete-memory.ts
@@ -1,0 +1,60 @@
+import { unlink, readFile } from "node:fs/promises";
+import { MemoryIndex } from "./memory-index";
+import { EventDispatcher } from "./event-dispatcher";
+
+function parseFrontmatter(content: string): Record<string, any> {
+  const match = content.match(/^---\n([\s\S]*?)\n---/);
+  if (!match) return {};
+  const result: Record<string, any> = {};
+  for (const line of match[1].split("\n")) {
+    const colonIdx = line.indexOf(":");
+    if (colonIdx === -1) continue;
+    const key = line.slice(0, colonIdx).trim();
+    const value = line.slice(colonIdx + 1).trim();
+    result[key] = value;
+  }
+  return result;
+}
+
+export interface DeleteMemoryDeps {
+  memoryIndex: MemoryIndex;
+  eventDispatcher: EventDispatcher;
+}
+
+/**
+ * Delete a memory by ID: removes the file from disk, updates the index,
+ * and emits a memory.deleted event. Returns true if deleted, false if not found.
+ */
+export async function deleteMemoryById(
+  id: string,
+  deps: DeleteMemoryDeps
+): Promise<boolean> {
+  const filePath = deps.memoryIndex.get(id);
+  if (!filePath) return false;
+
+  // Read frontmatter before deleting for the event payload
+  let frontmatter: Record<string, any> = {};
+  try {
+    const content = await readFile(filePath, "utf-8");
+    frontmatter = parseFrontmatter(content);
+  } catch {
+    // file may already be gone
+  }
+
+  try {
+    await unlink(filePath);
+  } catch {
+    return false;
+  }
+
+  deps.memoryIndex.delete(id);
+
+  await deps.eventDispatcher.emit("memory.deleted", {
+    id,
+    filePath,
+    frontmatter,
+    timestamp: new Date().toISOString(),
+  });
+
+  return true;
+}

--- a/apps/core-api/src/index.ts
+++ b/apps/core-api/src/index.ts
@@ -1,6 +1,7 @@
 import { createApp, ensureDataDirectories } from "./app";
 import type { QmdHealthSummary } from "./app";
 import { QueueRepository } from "./queue";
+import { PluginRegistryRepository } from "./plugin-registry";
 import { resolveDataPath, resolveQueueDbPath, resolveQmdDbPath, ensureKoreDirectories } from "./config";
 import { initLogger, closeLogger } from "./logger";
 import { startWorker } from "./worker";
@@ -8,7 +9,9 @@ import { startWatcher } from "./watcher";
 import { startEmbedInterval } from "./embedder";
 import { MemoryIndex } from "./memory-index";
 import { EventDispatcher } from "./event-dispatcher";
+import { deleteMemoryById } from "./delete-memory";
 import * as qmdClient from "@kore/qmd-client";
+import type { KorePlugin, PluginStartDeps } from "@kore/shared-types";
 
 initLogger();
 
@@ -38,7 +41,7 @@ const qmdStatus = async (): Promise<QmdHealthSummary> => {
   try {
     const index = await qmdClient.getStatus();
     const health = await qmdClient.getIndexHealth();
-    
+
     return {
       status: bootstrapping ? "bootstrapping" : "ok",
       doc_count: index.totalDocuments,
@@ -58,6 +61,42 @@ await memoryIndex.build(dataPath);
 console.log(`Memory index built: ${memoryIndex.size} files indexed`);
 
 const eventDispatcher = new EventDispatcher();
+
+// ── Initialize plugins ──────────────────────────────────────────────────
+
+// Plugin modules are imported explicitly (code-driven, not config-driven).
+// To add a new plugin, import it here and add it to the plugins array.
+const plugins: KorePlugin[] = [
+  // plugins registered here
+];
+
+// Create plugin registry from the same database instance as QueueRepository
+const pluginRegistry = new PluginRegistryRepository(queue.getDatabase());
+
+// Build PluginStartDeps for each plugin and call start()
+for (const plugin of plugins) {
+  if (plugin.start) {
+    const deps: PluginStartDeps = {
+      enqueue: (payload, priority) => queue.enqueue(payload, priority),
+      deleteMemory: (id) => deleteMemoryById(id, { memoryIndex, eventDispatcher }),
+      getMemoryIdByExternalKey: (externalKey) => pluginRegistry.get(plugin.name, externalKey),
+      setExternalKeyMapping: (externalKey, memoryId) => pluginRegistry.set(plugin.name, externalKey, memoryId),
+      removeExternalKeyMapping: (externalKey) => pluginRegistry.remove(plugin.name, externalKey),
+      clearRegistry: () => pluginRegistry.clear(plugin.name),
+    };
+
+    try {
+      await plugin.start(deps);
+      console.log(`Plugin "${plugin.name}" started`);
+    } catch (err) {
+      console.error(`Plugin "${plugin.name}" failed to start (non-fatal):`, err);
+    }
+  }
+}
+
+// Register all plugins with EventDispatcher
+eventDispatcher.registerPlugins(plugins);
+
 const app = createApp({
   dataPath,
   queue,
@@ -97,7 +136,7 @@ try {
 
 // ── Start background services ───────────────────────────────────────────
 
-const worker = startWorker({ queue, dataPath });
+const worker = startWorker({ queue, dataPath, dispatcher: eventDispatcher });
 console.log("Kore extraction worker started (polling every 5s)");
 
 const watcher = startWatcher({ dataPath });
@@ -108,11 +147,34 @@ console.log("Kore embed interval started");
 
 // ── Graceful shutdown ───────────────────────────────────────────────────
 
+const PLUGIN_STOP_TIMEOUT_MS = 5_000;
+
 async function shutdown() {
   console.log("Shutting down...");
   watcher.stop();
   embedder.stop();
   worker.stop();
+
+  // Stop plugins gracefully with timeout
+  for (const plugin of plugins) {
+    if (plugin.stop) {
+      try {
+        await Promise.race([
+          plugin.stop(),
+          new Promise<void>((_, reject) =>
+            setTimeout(() => reject(new Error("timeout")), PLUGIN_STOP_TIMEOUT_MS)
+          ),
+        ]);
+        console.log(`Plugin "${plugin.name}" stopped`);
+      } catch (err) {
+        const msg = err instanceof Error && err.message === "timeout"
+          ? `Plugin "${plugin.name}" stop() timed out after ${PLUGIN_STOP_TIMEOUT_MS}ms, continuing shutdown`
+          : `Plugin "${plugin.name}" stop() failed: ${err}`;
+        console.warn(msg);
+      }
+    }
+  }
+
   await qmdClient.closeStore();
   console.log("QMD store closed");
   closeLogger();

--- a/apps/core-api/src/plugin-lifecycle.test.ts
+++ b/apps/core-api/src/plugin-lifecycle.test.ts
@@ -1,0 +1,307 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { pollOnce, type WorkerDeps } from "./worker";
+import { QueueRepository } from "./queue";
+import { EventDispatcher } from "./event-dispatcher";
+import { PluginRegistryRepository } from "./plugin-registry";
+import { deleteMemoryById } from "./delete-memory";
+import { MemoryIndex } from "./memory-index";
+import { ensureDataDirectories } from "./app";
+import type { MemoryExtraction, MemoryEvent, KorePlugin, PluginStartDeps } from "@kore/shared-types";
+import { join } from "node:path";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { renderMarkdown } from "./markdown";
+import { randomUUID } from "crypto";
+
+// ─── Mock extract function ──────────────────────────────────────────
+
+const MOCK_EXTRACTION: MemoryExtraction = {
+  title: "Mutekiya Ramen in Ikebukuro",
+  distilled_items: [
+    "Mutekiya is a famous tonkotsu ramen shop in Ikebukuro, Tokyo",
+    "Known for rich, creamy pork broth and thick noodles",
+  ],
+  qmd_category: "qmd://travel/food/japan",
+  type: "place",
+  tags: ["ramen", "tokyo"],
+};
+
+function mockExtract(): Promise<MemoryExtraction> {
+  return Promise.resolve(MOCK_EXTRACTION);
+}
+
+function failingExtract(): Promise<MemoryExtraction> {
+  return Promise.reject(new Error("LLM connection refused"));
+}
+
+// ─── Per-test isolation ─────────────────────────────────────────────
+
+let tempDir: string;
+let queue: QueueRepository;
+let dispatcher: EventDispatcher;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "kore-plugin-lifecycle-test-"));
+  await ensureDataDirectories(tempDir);
+  const dbPath = join(tempDir, "queue.db");
+  queue = new QueueRepository(dbPath);
+  dispatcher = new EventDispatcher();
+});
+
+afterEach(async () => {
+  queue.close();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+function makeDeps(overrides?: Partial<WorkerDeps>): WorkerDeps {
+  return {
+    queue,
+    dataPath: tempDir,
+    dispatcher,
+    extractFn: mockExtract,
+    ...overrides,
+  };
+}
+
+// ─── Worker memory.indexed emission ─────────────────────────────────
+
+describe("Worker: memory.indexed emission", () => {
+  test("emits memory.indexed after successful extraction with correct taskId", async () => {
+    const events: MemoryEvent[] = [];
+    const plugin: KorePlugin = {
+      name: "test-plugin",
+      onMemoryIndexed: async (event) => { events.push(event); },
+    };
+    dispatcher.registerPlugins([plugin]);
+
+    const taskId = queue.enqueue({ source: "apple_notes", content: "Great ramen" });
+    await pollOnce(makeDeps());
+
+    expect(events).toHaveLength(1);
+    expect(events[0].taskId).toBe(taskId);
+    expect(events[0].id).toBeDefined();
+    expect(events[0].filePath).toContain("places/");
+    expect(events[0].frontmatter).toBeDefined();
+    expect(events[0].frontmatter.type).toBe("place");
+    expect(events[0].timestamp).toBeDefined();
+  });
+
+  test("does NOT emit event on extraction failure", async () => {
+    const events: MemoryEvent[] = [];
+    const plugin: KorePlugin = {
+      name: "test-plugin",
+      onMemoryIndexed: async (event) => { events.push(event); },
+    };
+    dispatcher.registerPlugins([plugin]);
+
+    queue.enqueue({ source: "test", content: "Some text" });
+    await pollOnce(makeDeps({ extractFn: failingExtract }));
+
+    expect(events).toHaveLength(0);
+  });
+
+  test("does NOT emit when no dispatcher is provided", async () => {
+    // This ensures backward compatibility
+    const taskId = queue.enqueue({ source: "test", content: "Some text" });
+    await pollOnce(makeDeps({ dispatcher: undefined }));
+
+    const task = queue.getTask(taskId);
+    expect(task?.status).toBe("completed");
+  });
+});
+
+// ─── Plugin lifecycle ───────────────────────────────────────────────
+
+describe("Plugin lifecycle", () => {
+  test("plugins with start() have it called during boot", async () => {
+    let started = false;
+    const plugin: KorePlugin = {
+      name: "start-test",
+      start: async () => { started = true; },
+    };
+
+    const registry = new PluginRegistryRepository(queue.getDatabase());
+    const memoryIndex = new MemoryIndex();
+    const deps: PluginStartDeps = {
+      enqueue: (payload, priority) => queue.enqueue(payload, priority),
+      deleteMemory: (id) => deleteMemoryById(id, { memoryIndex, eventDispatcher: dispatcher }),
+      getMemoryIdByExternalKey: (key) => registry.get(plugin.name, key),
+      setExternalKeyMapping: (key, memId) => registry.set(plugin.name, key, memId),
+      removeExternalKeyMapping: (key) => registry.remove(plugin.name, key),
+      clearRegistry: () => registry.clear(plugin.name),
+    };
+
+    await plugin.start!(deps);
+    expect(started).toBe(true);
+  });
+
+  test("plugins without start() are skipped gracefully", async () => {
+    const plugin: KorePlugin = {
+      name: "hooks-only",
+      onMemoryIndexed: async () => {},
+    };
+
+    // Should not throw
+    if (plugin.start) {
+      await plugin.start({} as PluginStartDeps);
+    }
+    // If we get here, the plugin was skipped gracefully
+    expect(plugin.start).toBeUndefined();
+  });
+
+  test("a failing plugin start() does not crash the server", async () => {
+    const plugin: KorePlugin = {
+      name: "crasher",
+      start: async () => { throw new Error("plugin init crash"); },
+    };
+
+    let crashed = false;
+    try {
+      await plugin.start!({} as PluginStartDeps);
+    } catch {
+      crashed = true;
+    }
+
+    // The error should be caught — in index.ts this is wrapped in try/catch
+    expect(crashed).toBe(true);
+
+    // Simulate the index.ts pattern: catch and continue
+    const plugins: KorePlugin[] = [
+      plugin,
+      { name: "good-plugin", start: async () => {} },
+    ];
+
+    const results: string[] = [];
+    for (const p of plugins) {
+      if (p.start) {
+        try {
+          await p.start({} as PluginStartDeps);
+          results.push(`${p.name}:ok`);
+        } catch {
+          results.push(`${p.name}:error`);
+        }
+      }
+    }
+
+    expect(results).toEqual(["crasher:error", "good-plugin:ok"]);
+  });
+
+  test("plugin stop() is called during shutdown", async () => {
+    let stopped = false;
+    const plugin: KorePlugin = {
+      name: "stop-test",
+      stop: async () => { stopped = true; },
+    };
+
+    await plugin.stop!();
+    expect(stopped).toBe(true);
+  });
+
+  test("plugin stop() timeout is handled gracefully", async () => {
+    const plugin: KorePlugin = {
+      name: "slow-stopper",
+      stop: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10_000));
+      },
+    };
+
+    const TIMEOUT_MS = 100; // short timeout for test
+    let timedOut = false;
+
+    try {
+      await Promise.race([
+        plugin.stop!(),
+        new Promise<void>((_, reject) =>
+          setTimeout(() => reject(new Error("timeout")), TIMEOUT_MS)
+        ),
+      ]);
+    } catch (err) {
+      if (err instanceof Error && err.message === "timeout") {
+        timedOut = true;
+      }
+    }
+
+    expect(timedOut).toBe(true);
+  });
+});
+
+// ─── PluginStartDeps registry scoping ───────────────────────────────
+
+describe("PluginStartDeps: registry scoping", () => {
+  test("registry methods are scoped by plugin name via closure", () => {
+    const registry = new PluginRegistryRepository(queue.getDatabase());
+
+    // Build deps for plugin A
+    const depsA: PluginStartDeps = {
+      enqueue: (payload, priority) => queue.enqueue(payload, priority),
+      deleteMemory: async () => false,
+      getMemoryIdByExternalKey: (key) => registry.get("plugin-a", key),
+      setExternalKeyMapping: (key, memId) => registry.set("plugin-a", key, memId),
+      removeExternalKeyMapping: (key) => registry.remove("plugin-a", key),
+      clearRegistry: () => registry.clear("plugin-a"),
+    };
+
+    // Build deps for plugin B
+    const depsB: PluginStartDeps = {
+      enqueue: (payload, priority) => queue.enqueue(payload, priority),
+      deleteMemory: async () => false,
+      getMemoryIdByExternalKey: (key) => registry.get("plugin-b", key),
+      setExternalKeyMapping: (key, memId) => registry.set("plugin-b", key, memId),
+      removeExternalKeyMapping: (key) => registry.remove("plugin-b", key),
+      clearRegistry: () => registry.clear("plugin-b"),
+    };
+
+    // Plugin A sets a mapping
+    depsA.setExternalKeyMapping("note-123", "memory-abc");
+
+    // Plugin A can see it
+    expect(depsA.getMemoryIdByExternalKey("note-123")).toBe("memory-abc");
+
+    // Plugin B cannot see it
+    expect(depsB.getMemoryIdByExternalKey("note-123")).toBeUndefined();
+  });
+});
+
+// ─── deleteMemoryById shared function ───────────────────────────────
+
+describe("deleteMemoryById", () => {
+  test("deletes file and emits memory.deleted event", async () => {
+    const memoryIndex = new MemoryIndex();
+    const events: MemoryEvent[] = [];
+    const plugin: KorePlugin = {
+      name: "test-plugin",
+      onMemoryDeleted: async (event) => { events.push(event); },
+    };
+    dispatcher.registerPlugins([plugin]);
+
+    // Create a memory file
+    const id = randomUUID();
+    const filePath = join(tempDir, "notes", "test_delete.md");
+    const md = renderMarkdown({
+      frontmatter: {
+        id,
+        type: "note" as const,
+        category: "qmd://tech/test",
+        date_saved: "2026-03-15T12:00:00Z",
+        source: "test",
+        tags: ["test"],
+      },
+      title: "Test Delete",
+      rawSource: "Content",
+    });
+    await writeFile(filePath, md);
+    memoryIndex.set(id, filePath);
+
+    const deleted = await deleteMemoryById(id, { memoryIndex, eventDispatcher: dispatcher });
+    expect(deleted).toBe(true);
+    expect(memoryIndex.get(id)).toBeUndefined();
+    expect(events).toHaveLength(1);
+    expect(events[0].id).toBe(id);
+  });
+
+  test("returns false for unknown memory id", async () => {
+    const memoryIndex = new MemoryIndex();
+    const deleted = await deleteMemoryById("nonexistent", { memoryIndex, eventDispatcher: dispatcher });
+    expect(deleted).toBe(false);
+  });
+});

--- a/apps/core-api/src/queue.ts
+++ b/apps/core-api/src/queue.ts
@@ -159,6 +159,11 @@ export class QueueRepository {
     return row.count;
   }
 
+  /** Expose the underlying Database instance for sharing with other repositories. */
+  getDatabase(): Database {
+    return this.db;
+  }
+
   close(): void {
     this.db.close();
   }

--- a/apps/core-api/src/worker.ts
+++ b/apps/core-api/src/worker.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from "crypto";
 import { join } from "node:path";
 import { QueueRepository } from "./queue";
+import { EventDispatcher } from "./event-dispatcher";
 import { extract } from "@kore/llm-extractor";
 import { MemoryExtractionSchema } from "@kore/shared-types";
 import type { BaseFrontmatter } from "@kore/shared-types";
@@ -20,6 +21,7 @@ const CLEANUP_INTERVAL_MS = 60 * 60 * 1_000; // 1 hour
 export interface WorkerDeps {
   queue: QueueRepository;
   dataPath: string;
+  dispatcher?: EventDispatcher;
   extractFn?: typeof extract;
   pollIntervalMs?: number;
 }
@@ -46,6 +48,12 @@ async function resolveFilePath(
   return filePath;
 }
 
+interface ProcessTaskResult {
+  id: string;
+  filePath: string;
+  frontmatter: BaseFrontmatter;
+}
+
 /**
  * Process a single task: extract structured data via LLM, write the
  * canonical Markdown file to disk, and update the queue status.
@@ -54,7 +62,7 @@ async function processTask(
   taskId: string,
   payload: { source: string; content: string; original_url?: string },
   deps: WorkerDeps
-): Promise<string> {
+): Promise<ProcessTaskResult> {
   const extractFn = deps.extractFn || extract;
 
   // Call the LLM extractor
@@ -92,7 +100,7 @@ async function processTask(
   // Mark completed
   deps.queue.markCompleted(taskId);
 
-  return filePath;
+  return { id, filePath, frontmatter };
 }
 
 /**
@@ -106,8 +114,20 @@ export async function pollOnce(deps: WorkerDeps): Promise<boolean> {
   try {
     const payload = JSON.parse(task.payload);
     console.log(`Worker: processing task ${task.id} (source: ${payload.source}, attempt ${task.retries + 1})`);
-    await processTask(task.id, payload, deps);
+    const result = await processTask(task.id, payload, deps);
     console.log(`Worker: task ${task.id} completed`);
+
+    // Emit memory.indexed event after successful extraction
+    if (deps.dispatcher) {
+      await deps.dispatcher.emit("memory.indexed", {
+        id: result.id,
+        filePath: result.filePath,
+        frontmatter: result.frontmatter,
+        timestamp: new Date().toISOString(),
+        taskId: task.id,
+      });
+    }
+
     return true;
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);


### PR DESCRIPTION
Closes #51

### Summary
- Worker now emits `memory.indexed` event via `EventDispatcher` after successfully writing a memory file, with `taskId` from the dequeued task
- Extracted `deleteMemoryById()` from `app.ts` DELETE route into a shared module (`delete-memory.ts`) for reuse by both the API route and `PluginStartDeps`
- Added `getDatabase()` to `QueueRepository` to share the DB instance with `PluginRegistryRepository`
- Wired full plugin lifecycle in `index.ts`: plugin start with `PluginStartDeps` (scoped registry via closure), event dispatcher registration, dispatcher passed to worker, graceful shutdown with 5-second per-plugin timeout
- Plugin start errors are caught and logged (non-blocking); plugin stop uses `Promise.race` with timeout
- 11 new tests covering: worker event emission (success + failure cases), plugin start/stop lifecycle, failing plugin isolation, registry scoping, deleteMemoryById shared function
- All 134 existing tests pass with zero regressions