### PR TITLE
feat: PLUG-004 Test plugin for end-to-end validation

### DIFF
--- a/apps/core-api/src/index.ts
+++ b/apps/core-api/src/index.ts
@@ -66,9 +66,14 @@ const eventDispatcher = new EventDispatcher();
 
 // Plugin modules are imported explicitly (code-driven, not config-driven).
 // To add a new plugin, import it here and add it to the plugins array.
-const plugins: KorePlugin[] = [
-  // plugins registered here
-];
+const plugins: KorePlugin[] = [];
+
+// Conditionally load test plugin for end-to-end validation
+if (process.env.KORE_TEST_PLUGIN === "true") {
+  const { default: testPlugin } = await import("@kore/plugin-test");
+  plugins.push(testPlugin);
+  console.log("Test plugin loaded (KORE_TEST_PLUGIN=true)");
+}
 
 // Create plugin registry from the same database instance as QueueRepository
 const pluginRegistry = new PluginRegistryRepository(queue.getDatabase());

--- a/packages/plugin-test/__tests__/index.test.ts
+++ b/packages/plugin-test/__tests__/index.test.ts
@@ -1,0 +1,192 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { createApp, ensureDataDirectories } from "../../../apps/core-api/src/app";
+import { QueueRepository } from "../../../apps/core-api/src/queue";
+import { PluginRegistryRepository } from "../../../apps/core-api/src/plugin-registry";
+import { EventDispatcher } from "../../../apps/core-api/src/event-dispatcher";
+import { MemoryIndex } from "../../../apps/core-api/src/memory-index";
+import { pollOnce, type WorkerDeps } from "../../../apps/core-api/src/worker";
+import { deleteMemoryById } from "../../../apps/core-api/src/delete-memory";
+import testPlugin from "../index";
+import type { MemoryExtraction, PluginStartDeps } from "@kore/shared-types";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+
+// ─── Mock extract function ──────────────────────────────────────────
+
+const MOCK_EXTRACTION: MemoryExtraction = {
+  title: "Test Integration Memory",
+  distilled_items: [
+    "This is a test memory for plugin integration testing",
+  ],
+  qmd_category: "qmd://test/integration",
+  type: "note",
+  tags: ["test"],
+};
+
+function mockExtract(): Promise<MemoryExtraction> {
+  return Promise.resolve(MOCK_EXTRACTION);
+}
+
+// ─── Per-test isolation ─────────────────────────────────────────────
+
+let tempDir: string;
+let queue: QueueRepository;
+let pluginRegistry: PluginRegistryRepository;
+let dispatcher: EventDispatcher;
+let memoryIndex: MemoryIndex;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "kore-plugin-test-e2e-"));
+  await ensureDataDirectories(tempDir);
+  const dbPath = join(tempDir, "queue.db");
+  queue = new QueueRepository(dbPath);
+  pluginRegistry = new PluginRegistryRepository(queue.getDatabase());
+  dispatcher = new EventDispatcher();
+  memoryIndex = new MemoryIndex();
+});
+
+afterEach(async () => {
+  // Stop the test plugin to clean up state between tests
+  if (testPlugin.stop) {
+    await testPlugin.stop();
+  }
+  queue.close();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+// ─── Integration tests ─────────────────────────────────────────────
+
+describe("Test plugin: end-to-end integration", () => {
+  test("full flow: ingest → worker → onMemoryIndexed → key mapping persisted", async () => {
+    // 1. Build PluginStartDeps and start the test plugin
+    const deps: PluginStartDeps = {
+      enqueue: (payload, priority) => queue.enqueue(payload, priority),
+      deleteMemory: (id) => deleteMemoryById(id, { memoryIndex, eventDispatcher: dispatcher }),
+      getMemoryIdByExternalKey: (key) => pluginRegistry.get("test-plugin", key),
+      setExternalKeyMapping: (key, memId) => pluginRegistry.set("test-plugin", key, memId),
+      removeExternalKeyMapping: (key) => pluginRegistry.remove("test-plugin", key),
+      clearRegistry: () => pluginRegistry.clear("test-plugin"),
+    };
+
+    await testPlugin.start!(deps);
+
+    // 2. Register plugin with event dispatcher
+    dispatcher.registerPlugins([testPlugin]);
+
+    // 3. Create the app and POST to /api/v1/ingest/raw
+    process.env.KORE_API_KEY = "test-key";
+    const app = createApp({
+      queue,
+      dataPath: tempDir,
+      memoryIndex,
+      eventDispatcher: dispatcher,
+      qmdStatus: async () => ({ status: "ok" as const }),
+    });
+
+    const response = await app.handle(
+      new Request("http://localhost/api/v1/ingest/raw", {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer test-key",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          source: "test-integration",
+          content: "This is test content for plugin integration",
+        }),
+      })
+    );
+
+    expect(response.status).toBe(202);
+    const body = await response.json();
+    const taskId = body.task_id;
+    expect(taskId).toBeDefined();
+
+    // 4. Run the worker to process the task
+    const workerDeps: WorkerDeps = {
+      queue,
+      dataPath: tempDir,
+      dispatcher,
+      extractFn: mockExtract,
+    };
+
+    const processed = await pollOnce(workerDeps);
+    expect(processed).toBe(true);
+
+    // 5. Verify the external key mapping was persisted in plugin_key_registry
+    const memoryId = pluginRegistry.get("test-plugin", `task:${taskId}`);
+    expect(memoryId).toBeDefined();
+    expect(typeof memoryId).toBe("string");
+
+    // 6. Verify the mapping points to a valid UUID
+    expect(memoryId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+    );
+  });
+
+  test("onMemoryIndexed receives valid taskId", async () => {
+    // Track events received by the plugin
+    const receivedEvents: Array<{ id: string; taskId?: string }> = [];
+    const originalHandler = testPlugin.onMemoryIndexed!;
+
+    // Wrap the handler to capture events
+    testPlugin.onMemoryIndexed = async (event) => {
+      receivedEvents.push({ id: event.id, taskId: event.taskId });
+      await originalHandler(event);
+    };
+
+    const deps: PluginStartDeps = {
+      enqueue: (payload, priority) => queue.enqueue(payload, priority),
+      deleteMemory: (id) => deleteMemoryById(id, { memoryIndex, eventDispatcher: dispatcher }),
+      getMemoryIdByExternalKey: (key) => pluginRegistry.get("test-plugin", key),
+      setExternalKeyMapping: (key, memId) => pluginRegistry.set("test-plugin", key, memId),
+      removeExternalKeyMapping: (key) => pluginRegistry.remove("test-plugin", key),
+      clearRegistry: () => pluginRegistry.clear("test-plugin"),
+    };
+
+    await testPlugin.start!(deps);
+    dispatcher.registerPlugins([testPlugin]);
+
+    // Enqueue and process
+    const taskId = queue.enqueue({ source: "test", content: "Test content" });
+    await pollOnce({ queue, dataPath: tempDir, dispatcher, extractFn: mockExtract });
+
+    // Verify the plugin received the event with a valid taskId
+    expect(receivedEvents).toHaveLength(1);
+    expect(receivedEvents[0].taskId).toBe(taskId);
+    expect(receivedEvents[0].id).toBeDefined();
+
+    // Restore original handler
+    testPlugin.onMemoryIndexed = originalHandler;
+  });
+
+  test("plugin start/stop lifecycle works correctly", async () => {
+    const deps: PluginStartDeps = {
+      enqueue: (payload, priority) => queue.enqueue(payload, priority),
+      deleteMemory: async () => false,
+      getMemoryIdByExternalKey: (key) => pluginRegistry.get("test-plugin", key),
+      setExternalKeyMapping: (key, memId) => pluginRegistry.set("test-plugin", key, memId),
+      removeExternalKeyMapping: (key) => pluginRegistry.remove("test-plugin", key),
+      clearRegistry: () => pluginRegistry.clear("test-plugin"),
+    };
+
+    // start() should not throw
+    await testPlugin.start!(deps);
+
+    // After start, setExternalKeyMapping should work (deps stored)
+    // Simulate an onMemoryIndexed call
+    await testPlugin.onMemoryIndexed!({
+      id: "mem-1",
+      filePath: "/tmp/test.md",
+      frontmatter: { id: "mem-1", type: "note" },
+      timestamp: new Date().toISOString(),
+      taskId: "task-1",
+    });
+
+    expect(pluginRegistry.get("test-plugin", "task:task-1")).toBe("mem-1");
+
+    // stop() should not throw
+    await testPlugin.stop!();
+  });
+});

--- a/packages/plugin-test/index.ts
+++ b/packages/plugin-test/index.ts
@@ -1,0 +1,26 @@
+import type { KorePlugin, PluginStartDeps, MemoryEvent } from "@kore/shared-types";
+
+let deps: PluginStartDeps | null = null;
+
+const testPlugin: KorePlugin = {
+  name: "test-plugin",
+
+  async start(d: PluginStartDeps) {
+    deps = d;
+    console.log("[test-plugin] started");
+  },
+
+  async stop() {
+    deps = null;
+    console.log("[test-plugin] stopped");
+  },
+
+  async onMemoryIndexed(event: MemoryEvent) {
+    console.log("[test-plugin] onMemoryIndexed:", event.id, "taskId:", event.taskId);
+    if (deps && event.taskId) {
+      deps.setExternalKeyMapping(`task:${event.taskId}`, event.id);
+    }
+  },
+};
+
+export default testPlugin;

--- a/packages/plugin-test/package.json
+++ b/packages/plugin-test/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "@kore/plugin-test",
+  "version": "1.0.0",
+  "main": "index.ts",
+  "dependencies": {
+    "@kore/shared-types": "workspace:*"
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,6 +20,9 @@
       ],
       "@kore/shared-types": [
         "packages/shared-types/index.ts"
+      ],
+      "@kore/plugin-test": [
+        "packages/plugin-test/index.ts"
       ]
     }
   },


### PR DESCRIPTION
Closes #52

### Summary
- Added `packages/plugin-test/` with a minimal `KorePlugin` (`test-plugin`) that exercises start/stop lifecycle, `onMemoryIndexed` event handling, and external key mapping via `PluginStartDeps.setExternalKeyMapping()`
- Conditionally loaded in `apps/core-api/src/index.ts` when `KORE_TEST_PLUGIN=true` env var is set
- Integration tests verify the full end-to-end flow: POST to `/api/v1/ingest/raw` → worker processes task → `onMemoryIndexed` fires with valid `taskId` → key mapping persisted in `plugin_key_registry`
- Added `@kore/plugin-test` path mapping to `tsconfig.json` for typecheck support
- All 447 tests pass, typecheck clean