### PR TITLE
feat: Add intent and confidence to extraction schema and frontmatter (EXTR-001)

### DIFF
--- a/apps/core-api/src/app.ts
+++ b/apps/core-api/src/app.ts
@@ -118,6 +118,8 @@ async function parseMemoryFile(id: string, filePath: string): Promise<MemorySumm
       source: fm.source || "",
       date_saved: fm.date_saved || "",
       tags: parseTagsArray(fm.tags || ""),
+      ...(fm.intent ? { intent: fm.intent } : {}),
+      ...(fm.confidence !== undefined ? { confidence: parseFloat(fm.confidence) } : {}),
     };
   } catch {
     return null;
@@ -137,6 +139,8 @@ async function parseMemoryFileFull(id: string, filePath: string): Promise<Memory
       source: fm.source || "",
       tags: parseTagsArray(fm.tags || ""),
       url: fm.url,
+      ...(fm.intent ? { intent: fm.intent } : {}),
+      ...(fm.confidence !== undefined ? { confidence: parseFloat(fm.confidence) } : {}),
       title: extractTitleFromMarkdown(content),
       content,
     };
@@ -152,6 +156,8 @@ interface MemorySummary {
   source: string;
   date_saved: string;
   tags: string[];
+  intent?: string;
+  confidence?: number;
 }
 
 interface MemoryFull extends MemorySummary {

--- a/apps/core-api/src/markdown.ts
+++ b/apps/core-api/src/markdown.ts
@@ -23,6 +23,12 @@ export function renderMarkdown(opts: {
   if (frontmatter.url) {
     yamlLines.push(`url: ${frontmatter.url}`);
   }
+  if (frontmatter.intent) {
+    yamlLines.push(`intent: ${frontmatter.intent}`);
+  }
+  if (frontmatter.confidence !== undefined) {
+    yamlLines.push(`confidence: ${frontmatter.confidence}`);
+  }
   yamlLines.push("---");
 
   const sections = [

--- a/apps/core-api/src/worker.test.ts
+++ b/apps/core-api/src/worker.test.ts
@@ -3,6 +3,7 @@ import { pollOnce, startWorker, type WorkerDeps } from "./worker";
 import { QueueRepository } from "./queue";
 import { ensureDataDirectories } from "./app";
 import type { MemoryExtraction } from "@kore/shared-types";
+import { renderMarkdown } from "./markdown";
 import { join } from "node:path";
 import { mkdtemp, rm, readdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -304,5 +305,73 @@ describe("E2E: POST /ingest/raw → worker → .md file", () => {
     expect(statusBody.status).toBe("completed");
 
     e2eQueue.close();
+  });
+});
+
+// ─── Worker: intent/confidence handling ──────────────────────────
+
+describe("Worker: intent and confidence", () => {
+  test("defaults intent to 'reference' when absent from extraction result", async () => {
+    const extractNoIntent = () =>
+      Promise.resolve({ ...MOCK_EXTRACTION }); // no intent field
+
+    const payload = { source: "test", content: "Some text" };
+    queue.enqueue(payload);
+
+    await pollOnce(makeDeps({ extractFn: extractNoIntent }));
+
+    const files = await readdir(join(tempDir, "places"));
+    const content = await readFile(join(tempDir, "places", files[0]), "utf-8");
+    expect(content).toContain("intent: reference");
+  });
+
+  test("passes through intent and confidence to frontmatter when present", async () => {
+    const extractWithIntentAndConfidence = () =>
+      Promise.resolve({
+        ...MOCK_EXTRACTION,
+        intent: "recommendation" as const,
+        confidence: 0.92,
+      });
+
+    const payload = { source: "test", content: "Some text" };
+    queue.enqueue(payload);
+
+    await pollOnce(makeDeps({ extractFn: extractWithIntentAndConfidence }));
+
+    const files = await readdir(join(tempDir, "places"));
+    const content = await readFile(join(tempDir, "places", files[0]), "utf-8");
+    expect(content).toContain("intent: recommendation");
+    expect(content).toContain("confidence: 0.92");
+  });
+});
+
+// ─── renderMarkdown: intent/confidence ───────────────────────────
+
+describe("renderMarkdown: intent and confidence", () => {
+  const baseFrontmatter = {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    type: "place" as const,
+    category: "qmd://travel/food/japan",
+    date_saved: "2026-03-07T12:00:00Z",
+    source: "apple_notes",
+    tags: ["ramen", "tokyo"],
+  };
+
+  test("includes intent and confidence lines when present", () => {
+    const md = renderMarkdown({
+      frontmatter: { ...baseFrontmatter, intent: "recommendation" as const, confidence: 0.95 },
+      title: "Test",
+    });
+    expect(md).toContain("intent: recommendation");
+    expect(md).toContain("confidence: 0.95");
+  });
+
+  test("omits intent and confidence lines when absent", () => {
+    const md = renderMarkdown({
+      frontmatter: baseFrontmatter,
+      title: "Test",
+    });
+    expect(md).not.toContain("intent:");
+    expect(md).not.toContain("confidence:");
   });
 });

--- a/apps/core-api/src/worker.ts
+++ b/apps/core-api/src/worker.ts
@@ -71,6 +71,13 @@ async function processTask(
   // Validate against MemoryExtractionSchema
   const parsed = MemoryExtractionSchema.parse(raw);
 
+  // Determine intent (default to "reference" if absent)
+  let intent = parsed.intent;
+  if (!intent) {
+    console.warn(`Worker: intent not classified for task ${taskId}, defaulting to "reference"`);
+    intent = "reference";
+  }
+
   // Build frontmatter
   const id = randomUUID();
   const frontmatter: BaseFrontmatter = {
@@ -81,6 +88,8 @@ async function processTask(
     source: payload.source,
     tags: parsed.tags,
     ...(payload.original_url ? { url: payload.original_url } : {}),
+    intent,
+    ...(parsed.confidence !== undefined ? { confidence: parsed.confidence } : {}),
   };
 
   // Resolve file path with collision handling

--- a/packages/shared-types/index.test.ts
+++ b/packages/shared-types/index.test.ts
@@ -3,6 +3,7 @@ import {
   MemoryTypeEnum,
   BaseFrontmatterSchema,
   MemoryExtractionSchema,
+  IntentEnum,
 } from "./index";
 import type { KorePlugin, MemoryEvent } from "./index";
 
@@ -172,6 +173,64 @@ describe("MemoryExtractionSchema", () => {
     expect(() =>
       MemoryExtractionSchema.parse({ ...validExtraction, type: "bookmark" })
     ).toThrow();
+  });
+});
+
+// ─── IntentEnum & MemoryExtractionSchema intent/confidence ───────
+
+describe("IntentEnum", () => {
+  test("accepts all five valid intent values", () => {
+    const values = ["recommendation", "reference", "personal-experience", "aspiration", "how-to"] as const;
+    for (const v of values) {
+      expect(IntentEnum.parse(v)).toBe(v);
+    }
+  });
+
+  test("rejects invalid intent", () => {
+    expect(() => IntentEnum.parse("bookmark")).toThrow();
+  });
+});
+
+describe("MemoryExtractionSchema intent/confidence", () => {
+  const base = {
+    title: "Test",
+    distilled_items: ["Fact one"],
+    qmd_category: "qmd://test",
+    type: "note" as const,
+    tags: ["test"],
+  };
+
+  test("accepts all five valid intent values", () => {
+    const values = ["recommendation", "reference", "personal-experience", "aspiration", "how-to"] as const;
+    for (const v of values) {
+      const result = MemoryExtractionSchema.parse({ ...base, intent: v });
+      expect(result.intent).toBe(v);
+    }
+  });
+
+  test("accepts missing intent (optional)", () => {
+    const result = MemoryExtractionSchema.parse(base);
+    expect(result.intent).toBeUndefined();
+  });
+
+  test("rejects an invalid intent string", () => {
+    expect(() => MemoryExtractionSchema.parse({ ...base, intent: "bookmark" })).toThrow();
+  });
+
+  test("accepts confidence within [0, 1]", () => {
+    expect(MemoryExtractionSchema.parse({ ...base, confidence: 0.85 }).confidence).toBe(0.85);
+    expect(MemoryExtractionSchema.parse({ ...base, confidence: 0 }).confidence).toBe(0);
+    expect(MemoryExtractionSchema.parse({ ...base, confidence: 1 }).confidence).toBe(1);
+  });
+
+  test("rejects confidence outside [0, 1]", () => {
+    expect(() => MemoryExtractionSchema.parse({ ...base, confidence: 1.5 })).toThrow();
+    expect(() => MemoryExtractionSchema.parse({ ...base, confidence: -0.1 })).toThrow();
+  });
+
+  test("accepts missing confidence (optional)", () => {
+    const result = MemoryExtractionSchema.parse(base);
+    expect(result.confidence).toBeUndefined();
   });
 });
 

--- a/packages/shared-types/index.ts
+++ b/packages/shared-types/index.ts
@@ -6,6 +6,9 @@ import type { Elysia } from "elysia";
 export const MemoryTypeEnum = z.enum(["place", "media", "note", "person"]);
 export type MemoryType = z.infer<typeof MemoryTypeEnum>;
 
+export const IntentEnum = z.enum(["recommendation", "reference", "personal-experience", "aspiration", "how-to"]);
+export type Intent = z.infer<typeof IntentEnum>;
+
 export const BaseFrontmatterSchema = z.object({
   /** A stable UUIDv4 unique to this discrete memory */
   id: z.string().uuid(),
@@ -27,6 +30,12 @@ export const BaseFrontmatterSchema = z.object({
 
   /** The original URL if applicable (e.g. Safari Bookmark, Reddit thread) */
   url: z.string().url().optional(),
+
+  /** The intent/disposition of the memory */
+  intent: IntentEnum.optional(),
+
+  /** LLM extraction confidence score (0–1) */
+  confidence: z.number().min(0).max(1).optional(),
 });
 
 export type BaseFrontmatter = z.infer<typeof BaseFrontmatterSchema>;
@@ -62,6 +71,10 @@ export const MemoryExtractionSchema = z.object({
     .min(1)
     .max(5)
     .describe("Between 1 and 5 thematic tags. lowercase, kebab-case."),
+
+  intent: IntentEnum.optional().describe("The intent/disposition of the memory."),
+
+  confidence: z.number().min(0).max(1).optional().describe("Extraction confidence score between 0 and 1."),
 });
 
 export type MemoryExtraction = z.infer<typeof MemoryExtractionSchema>;


### PR DESCRIPTION
Closes #57

### Summary
- Defined `IntentEnum` with five values (`recommendation`, `reference`, `personal-experience`, `aspiration`, `how-to`) in `packages/shared-types/index.ts`
- Added optional `intent` and `confidence` fields to both `MemoryExtractionSchema` and `BaseFrontmatterSchema`
- Worker defaults `intent` to `"reference"` with a warning log when absent from LLM output
- `renderMarkdown` conditionally emits `intent` and `confidence` YAML lines
- `MemorySummary` and `MemoryFull` interfaces updated with `intent?` and `confidence?`
- `parseMemoryFile` and `parseMemoryFileFull` extract the new fields from frontmatter
- All fields are optional — existing memories are unaffected (no migration needed)
- 16 new tests covering schema validation, worker defaulting, and renderMarkdown output