### PR TITLE
feat: ANOTE-004 API routes, CLI command, and integration test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,20 @@ QMD_CACHE_PATH=~/.kore/qmd-cache
 
 # Interval (ms) between periodic embed() calls for vector embeddings (default: 5 min)
 KORE_EMBED_INTERVAL_MS=300000
+
+# ─── Apple Notes Plugin ─────────────────────────────────────────────
+# Enable the Apple Notes sync plugin (requires Full Disk Access on macOS)
+KORE_APPLE_NOTES_ENABLED=false
+
+# Sync interval in milliseconds (default: 900000 = 15 minutes)
+KORE_AN_SYNC_INTERVAL_MS=900000
+
+# Include handwriting OCR text from drawings (default: false)
+KORE_AN_INCLUDE_HANDWRITING=false
+
+# Comma-separated folder allowlist — only sync notes in these top-level folders
+# Leave empty to sync all folders (subject to blocklist)
+KORE_AN_FOLDER_ALLOWLIST=
+
+# Comma-separated folder blocklist — exclude notes in these top-level folders
+KORE_AN_FOLDER_BLOCKLIST=

--- a/apps/cli/src/commands/sync.ts
+++ b/apps/cli/src/commands/sync.ts
@@ -1,0 +1,85 @@
+import pc from "picocolors";
+import { apiFetch } from "../api.ts";
+import { API_URL } from "../utils/env.ts";
+
+interface StatusResponse {
+  enabled: boolean;
+  last_sync_at: string | null;
+  last_sync_result: string | null;
+  total_tracked_notes: number;
+  next_sync_in_seconds: number | null;
+  staging_path: string;
+}
+
+interface SyncResponse {
+  status: string;
+  message: string;
+}
+
+export async function syncCommand(opts: { status: boolean; json: boolean }): Promise<void> {
+  if (opts.status) {
+    const result = await apiFetch<StatusResponse>("/api/v1/plugins/apple-notes/status");
+
+    if (!result.ok) {
+      if (result.status === 0) {
+        process.stderr.write(`Error: ${result.message}\n`);
+      } else {
+        process.stderr.write(
+          `Error: Cannot reach Kore API at ${API_URL}. Is the server running?\n`
+        );
+      }
+      process.exit(1);
+    }
+
+    if (opts.json) {
+      process.stdout.write(JSON.stringify(result.data, null, 2) + "\n");
+      return;
+    }
+
+    const { enabled, last_sync_at, last_sync_result, total_tracked_notes, next_sync_in_seconds, staging_path } = result.data;
+
+    const enabledStr = enabled ? pc.green("enabled") : pc.red("disabled");
+    const resultStr = last_sync_result === "success"
+      ? pc.green(last_sync_result)
+      : last_sync_result === "error"
+        ? pc.red(last_sync_result)
+        : pc.dim("n/a");
+
+    const nextSyncStr = next_sync_in_seconds != null
+      ? `${Math.floor(next_sync_in_seconds / 60)}m ${next_sync_in_seconds % 60}s`
+      : pc.dim("n/a");
+
+    process.stdout.write(
+      [
+        `Apple Notes:    ${enabledStr}`,
+        `Last Sync:      ${last_sync_at ?? pc.dim("never")}`,
+        `Last Result:    ${resultStr}`,
+        `Tracked Notes:  ${total_tracked_notes}`,
+        `Next Sync In:   ${nextSyncStr}`,
+        `Staging Path:   ${staging_path}`,
+      ].join("\n") + "\n"
+    );
+    return;
+  }
+
+  // Trigger sync
+  const result = await apiFetch<SyncResponse>("/api/v1/plugins/apple-notes/sync", {
+    method: "POST",
+  });
+
+  if (!result.ok) {
+    if (result.status === 0) {
+      process.stderr.write(`Error: ${result.message}\n`);
+    } else {
+      process.stderr.write(`Error: Failed to trigger sync (${result.status}): ${result.message}\n`);
+    }
+    process.exit(1);
+  }
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(result.data, null, 2) + "\n");
+    return;
+  }
+
+  process.stdout.write(`Sync triggered. ${result.data.message}\n`);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -10,6 +10,7 @@ import { showCommand } from "./commands/show.ts";
 import { deleteCommand } from "./commands/delete.ts";
 import { searchCommand } from "./commands/search.ts";
 import { resetCommand } from "./commands/reset.ts";
+import { syncCommand } from "./commands/sync.ts";
 
 // Read version from package.json
 const pkg = await import("../package.json", { with: { type: "json" } });
@@ -115,6 +116,16 @@ program
   .option("--json", "Output results as JSON", false)
   .action(async (query, opts) => {
     await searchCommand(query, opts);
+  });
+
+// ─── sync ───────────────────────────────────────────────────────────────────
+program
+  .command("sync")
+  .description("Trigger Apple Notes sync or check sync status")
+  .option("--status", "Show sync status instead of triggering a sync", false)
+  .option("--json", "Output raw JSON", false)
+  .action(async (opts) => {
+    await syncCommand(opts);
   });
 
 // ─── reset ──────────────────────────────────────────────────────────────────

--- a/apps/core-api/src/index.ts
+++ b/apps/core-api/src/index.ts
@@ -110,7 +110,7 @@ for (const plugin of plugins) {
 // Register all plugins with EventDispatcher
 eventDispatcher.registerPlugins(plugins);
 
-const app = createApp({
+let app = createApp({
   dataPath,
   queue,
   memoryIndex,
@@ -118,6 +118,18 @@ const app = createApp({
   qmdStatus,
   searchFn: qmdClient.search,
 });
+
+// Mount plugin routes
+for (const plugin of plugins) {
+  if (plugin.routes) {
+    try {
+      plugin.routes(app as any);
+      console.log(`Plugin "${plugin.name}" routes mounted`);
+    } catch (err) {
+      console.error(`Plugin "${plugin.name}" routes failed (non-fatal):`, err);
+    }
+  }
+}
 
 app.listen(3000);
 console.log(`Kore Core API running on http://localhost:3000`);

--- a/bun.lock
+++ b/bun.lock
@@ -75,6 +75,7 @@
       "dependencies": {
         "@kore/an-export": "workspace:*",
         "@kore/shared-types": "workspace:*",
+        "elysia": "^1.2.25",
       },
     },
     "packages/plugin-test": {

--- a/docs/phase2/apple_notes_integration_design.md
+++ b/docs/phase2/apple_notes_integration_design.md
@@ -720,8 +720,13 @@ Instead of a polling interval, the Notes database could be watched for changes. 
 12. Add `KORE_AN_*` env vars to `.env.example`
 
 ### Phase 4: Validation
-13. Manual E2E test: export a real Apple Notes account, verify memories created correctly
-14. Test delete sync: delete a note in Apple Notes, verify Kore memory is removed on next cycle
-15. Test update sync: modify a note, verify Kore memory is refreshed
-16. Test folder filtering: verify allowlist/blocklist work correctly
-17. Test failure recovery: revoke Full Disk Access mid-sync, verify graceful error and recovery
+13. **Automated integration test**: `packages/plugin-apple-notes/__tests__/integration.test.ts` runs against the real test database at `e2e/notes-testdata/group.com.apple.notes/` using `an-export`'s `dbDir` option. Covers:
+    - Full sync cycle: `syncNotes()` → content builder → verify output structure (folder prefix, title, body)
+    - Folder path extraction for nested folders (verifies " / " separator)
+    - Attachment reference stripping (no raw `![](../attachments/...)` in output)
+    - Temp staging directory cleanup
+14. Manual E2E test: export a real Apple Notes account, verify memories created correctly
+15. Test delete sync: delete a note in Apple Notes, verify Kore memory is removed on next cycle
+16. Test update sync: modify a note, verify Kore memory is refreshed
+17. Test folder filtering: verify allowlist/blocklist work correctly
+18. Test failure recovery: revoke Full Disk Access mid-sync, verify graceful error and recovery

--- a/packages/plugin-apple-notes/__tests__/integration.test.ts
+++ b/packages/plugin-apple-notes/__tests__/integration.test.ts
@@ -1,0 +1,169 @@
+import { describe, test, expect, afterEach } from "bun:test";
+import { syncNotes, type SyncManifest } from "@kore/an-export";
+import { buildIngestContent } from "../content-builder";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { join, resolve } from "node:path";
+import { tmpdir } from "node:os";
+
+const TEST_DB_DIR = resolve(
+  import.meta.dir,
+  "../../../e2e/notes-testdata/group.com.apple.notes",
+);
+
+let tmpDirs: string[] = [];
+
+async function createTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "kore-integration-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(async () => {
+  for (const dir of tmpDirs) {
+    await rm(dir, { recursive: true, force: true });
+  }
+  tmpDirs = [];
+});
+
+describe("Apple Notes integration (real database)", () => {
+  test("syncNotes exports notes from test database", async () => {
+    const dest = await createTempDir();
+
+    const result = await syncNotes({
+      dest,
+      omitFirstLine: false,
+      includeTrashed: false,
+      includeHandwriting: false,
+      dbDir: TEST_DB_DIR,
+    });
+
+    expect(result.exported).toBeGreaterThan(0);
+    expect(result.failed.length).toBe(0);
+
+    // Verify manifest was created
+    const manifestFile = Bun.file(join(dest, "an-export-manifest.json"));
+    expect(await manifestFile.exists()).toBe(true);
+
+    const manifest: SyncManifest = await manifestFile.json();
+    expect(manifest.version).toBe(1);
+    expect(Object.keys(manifest.notes).length).toBeGreaterThan(0);
+  });
+
+  test("full sync cycle: export, build content, verify output structure", async () => {
+    const dest = await createTempDir();
+
+    await syncNotes({
+      dest,
+      omitFirstLine: false,
+      includeTrashed: false,
+      includeHandwriting: false,
+      dbDir: TEST_DB_DIR,
+    });
+
+    const manifestFile = Bun.file(join(dest, "an-export-manifest.json"));
+    const manifest: SyncManifest = await manifestFile.json();
+
+    const entries = Object.values(manifest.notes);
+    expect(entries.length).toBeGreaterThan(0);
+
+    // Process each exported note through the content builder
+    let processedCount = 0;
+    for (const entry of entries) {
+      const absolutePath = join(dest, entry.path);
+      const relativePath = `notes/${entry.path}`;
+
+      const content = await buildIngestContent(absolutePath, relativePath);
+      if (!content) continue; // empty files are skipped
+
+      processedCount++;
+
+      // Verify output structure
+      const lines = content.split("\n");
+
+      // Content should contain meaningful text
+      expect(content.trim().length).toBeGreaterThan(0);
+
+      // If the note has a # heading, content builder should extract it as Title:
+      const hasHeading = content.match(/^#\s+.+$/m);
+      if (hasHeading) {
+        const titleLine = lines.find((l) => l.startsWith("Title:"));
+        expect(titleLine).toBeDefined();
+      }
+
+      // If the note is in a folder (has path segments), should have folder prefix
+      const segments = entry.path.split("/");
+      if (segments.length > 1) {
+        const folderLine = lines.find((l) => l.startsWith("Apple Notes Folder:"));
+        expect(folderLine).toBeDefined();
+      }
+
+      // Content should not exceed 8000 characters
+      expect(content.length).toBeLessThanOrEqual(8000);
+    }
+
+    expect(processedCount).toBeGreaterThan(0);
+  });
+
+  test("folder path extraction for nested folders", async () => {
+    const dest = await createTempDir();
+
+    await syncNotes({
+      dest,
+      omitFirstLine: false,
+      includeTrashed: false,
+      includeHandwriting: false,
+      dbDir: TEST_DB_DIR,
+    });
+
+    const manifestFile = Bun.file(join(dest, "an-export-manifest.json"));
+    const manifest: SyncManifest = await manifestFile.json();
+
+    // Find notes that are in nested folders (path has 2+ directory segments)
+    const nestedNotes = Object.values(manifest.notes).filter(
+      (entry) => entry.path.split("/").length > 2,
+    );
+
+    for (const entry of nestedNotes) {
+      const absolutePath = join(dest, entry.path);
+      const relativePath = `notes/${entry.path}`;
+      const content = await buildIngestContent(absolutePath, relativePath);
+      if (!content) continue;
+
+      const folderLine = content.split("\n").find((l) => l.startsWith("Apple Notes Folder:"));
+      expect(folderLine).toBeDefined();
+
+      // Nested folder should contain " / " separator
+      if (entry.path.split("/").length > 2) {
+        expect(folderLine).toContain(" / ");
+      }
+    }
+  });
+
+  test("attachment references are stripped from content", async () => {
+    const dest = await createTempDir();
+
+    await syncNotes({
+      dest,
+      omitFirstLine: false,
+      includeTrashed: false,
+      includeHandwriting: false,
+      dbDir: TEST_DB_DIR,
+    });
+
+    const manifestFile = Bun.file(join(dest, "an-export-manifest.json"));
+    const manifest: SyncManifest = await manifestFile.json();
+
+    for (const entry of Object.values(manifest.notes)) {
+      const absolutePath = join(dest, entry.path);
+      const relativePath = `notes/${entry.path}`;
+      const content = await buildIngestContent(absolutePath, relativePath);
+      if (!content) continue;
+
+      // No raw local attachment references should remain
+      expect(content).not.toMatch(/!\[.*?\]\(\.\.\/attachments\//);
+
+      // If the original had attachments, they should be replaced with [Attachment: ...]
+      // (We can't guarantee the test DB has attachments, but we verify the pattern doesn't leak)
+    }
+  });
+});

--- a/packages/plugin-apple-notes/__tests__/routes.test.ts
+++ b/packages/plugin-apple-notes/__tests__/routes.test.ts
@@ -1,0 +1,93 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import type { PluginStartDeps } from "@kore/shared-types";
+import appleNotesPlugin from "../index";
+import { Elysia } from "elysia";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+let tmpHome: string;
+
+function createMockDeps(entries: Array<{ externalKey: string; memoryId: string; metadata?: string }> = []): PluginStartDeps {
+  return {
+    enqueue: () => "task-1",
+    deleteMemory: async () => true,
+    getMemoryIdByExternalKey: () => undefined,
+    setExternalKeyMapping: () => {},
+    removeExternalKeyMapping: () => {},
+    clearRegistry: () => {},
+    listExternalKeys: () => entries,
+  };
+}
+
+describe("AppleNotesPlugin routes", () => {
+  beforeEach(async () => {
+    tmpHome = await mkdtemp(join(tmpdir(), "kore-routes-test-"));
+    process.env.KORE_HOME = tmpHome;
+  });
+
+  afterEach(async () => {
+    if (appleNotesPlugin.stop) {
+      await appleNotesPlugin.stop();
+    }
+    delete process.env.KORE_HOME;
+    await rm(tmpHome, { recursive: true, force: true });
+  });
+
+  test("GET /api/v1/plugins/apple-notes/status returns correct shape", async () => {
+    const entries = [
+      { externalKey: "1", memoryId: "mem-a" },
+      { externalKey: "2", memoryId: "pending:task-1" },
+      { externalKey: "3", memoryId: "mem-b" },
+    ];
+    const deps = createMockDeps(entries);
+    await appleNotesPlugin.start!(deps);
+
+    const app = new Elysia();
+    appleNotesPlugin.routes!(app);
+
+    const res = await app.handle(new Request("http://localhost/api/v1/plugins/apple-notes/status"));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body).toHaveProperty("enabled", true);
+    expect(body).toHaveProperty("last_sync_at");
+    expect(body).toHaveProperty("last_sync_result");
+    expect(body).toHaveProperty("total_tracked_notes", 3);
+    expect(body).toHaveProperty("next_sync_in_seconds");
+    expect(typeof body.next_sync_in_seconds).toBe("number");
+    expect(body).toHaveProperty("staging_path");
+    expect(body.staging_path).toContain("staging/apple-notes");
+  });
+
+  test("GET /api/v1/plugins/apple-notes/status returns null sync state before first sync", async () => {
+    const deps = createMockDeps();
+    await appleNotesPlugin.start!(deps);
+
+    const app = new Elysia();
+    appleNotesPlugin.routes!(app);
+
+    const res = await app.handle(new Request("http://localhost/api/v1/plugins/apple-notes/status"));
+    const body = await res.json();
+
+    expect(body.last_sync_at).toBeNull();
+    expect(body.last_sync_result).toBeNull();
+  });
+
+  test("POST /api/v1/plugins/apple-notes/sync returns 202", async () => {
+    const deps = createMockDeps();
+    await appleNotesPlugin.start!(deps);
+
+    const app = new Elysia();
+    appleNotesPlugin.routes!(app);
+
+    const res = await app.handle(
+      new Request("http://localhost/api/v1/plugins/apple-notes/sync", { method: "POST" })
+    );
+    expect(res.status).toBe(202);
+
+    const body = await res.json();
+    expect(body).toHaveProperty("status", "sync_triggered");
+    expect(body).toHaveProperty("message");
+  });
+});

--- a/packages/plugin-apple-notes/index.ts
+++ b/packages/plugin-apple-notes/index.ts
@@ -1,10 +1,12 @@
 import type { KorePlugin, PluginStartDeps, MemoryEvent } from "@kore/shared-types";
-import { startSyncLoop, type SyncLoopOpts } from "./sync-loop";
+import { startSyncLoop, type SyncLoopOpts, type SyncLoopHandle } from "./sync-loop";
 import { mkdir } from "node:fs/promises";
 import { join } from "node:path";
+import { Elysia } from "elysia";
 
 let deps: PluginStartDeps | null = null;
-let syncHandle: { stop: () => void } | null = null;
+let syncHandle: SyncLoopHandle | null = null;
+let pluginStagingDir: string = "";
 
 const appleNotesPlugin: KorePlugin = {
   name: "apple-notes",
@@ -15,6 +17,7 @@ const appleNotesPlugin: KorePlugin = {
     // Resolve staging directory
     const koreHome = process.env.KORE_HOME || join(process.env.HOME || "~", ".kore");
     const stagingDir = join(koreHome, "staging", "apple-notes");
+    pluginStagingDir = stagingDir;
 
     // Create staging directories
     await mkdir(join(stagingDir, "notes"), { recursive: true });
@@ -51,6 +54,38 @@ const appleNotesPlugin: KorePlugin = {
     }
     deps = null;
     console.log("[apple-notes] Plugin stopped");
+  },
+
+  routes(app: Elysia): any {
+    return app
+      .get("/api/v1/plugins/apple-notes/status", () => {
+        const state = syncHandle?.getState();
+        const trackedNotes = deps?.listExternalKeys().length ?? 0;
+        const nextSyncInSeconds = state?.nextSyncAt
+          ? Math.max(0, Math.round((state.nextSyncAt - Date.now()) / 1000))
+          : null;
+
+        return {
+          enabled: true,
+          last_sync_at: state?.lastSyncAt ?? null,
+          last_sync_result: state?.lastSyncResult ?? null,
+          total_tracked_notes: trackedNotes,
+          next_sync_in_seconds: nextSyncInSeconds,
+          staging_path: pluginStagingDir,
+        };
+      })
+      .post("/api/v1/plugins/apple-notes/sync", async ({ set }) => {
+        if (!syncHandle) {
+          set.status = 503;
+          return { error: "Apple Notes plugin is not running" };
+        }
+
+        // Trigger sync in the background (don't await in the response)
+        syncHandle.triggerSync();
+
+        set.status = 202;
+        return { status: "sync_triggered", message: "Sync cycle started" };
+      });
   },
 
   async onMemoryIndexed(event: MemoryEvent) {

--- a/packages/plugin-apple-notes/package.json
+++ b/packages/plugin-apple-notes/package.json
@@ -4,6 +4,7 @@
   "main": "index.ts",
   "dependencies": {
     "@kore/an-export": "workspace:*",
-    "@kore/shared-types": "workspace:*"
+    "@kore/shared-types": "workspace:*",
+    "elysia": "^1.2.25"
   }
 }

--- a/packages/plugin-apple-notes/sync-loop.ts
+++ b/packages/plugin-apple-notes/sync-loop.ts
@@ -173,17 +173,32 @@ export async function runSyncCycle(
   return { newNotes, deletedNotes, updatedNotes, skipped };
 }
 
+export interface SyncLoopState {
+  lastSyncAt: string | null;
+  lastSyncResult: "success" | "error" | null;
+  nextSyncAt: number | null;
+}
+
+export interface SyncLoopHandle {
+  stop: () => void;
+  getState: () => SyncLoopState;
+  triggerSync: () => Promise<void>;
+}
+
 /**
- * Start the background sync loop. Returns a handle with a stop() function.
+ * Start the background sync loop. Returns a handle with stop(), getState(), and triggerSync().
  */
 export function startSyncLoop(
   deps: PluginStartDeps,
   opts: SyncLoopOpts,
-): { stop: () => void } {
+): SyncLoopHandle {
   const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
   let running = false;
   let stopped = false;
   let timer: ReturnType<typeof setTimeout> | null = null;
+  let lastSyncAt: string | null = null;
+  let lastSyncResult: "success" | "error" | null = null;
+  let nextSyncAt: number | null = null;
 
   async function cycle() {
     if (stopped) return;
@@ -195,10 +210,14 @@ export function startSyncLoop(
     running = true;
     try {
       const result = await runSyncCycle(deps, opts);
+      lastSyncAt = new Date().toISOString();
+      lastSyncResult = "success";
       console.log(
         `[apple-notes] Sync complete: ${result.newNotes} new, ${result.updatedNotes} updated, ${result.deletedNotes} deleted, ${result.skipped} skipped`,
       );
     } catch (err) {
+      lastSyncAt = new Date().toISOString();
+      lastSyncResult = "error";
       console.error("[apple-notes] Sync cycle error (non-fatal):", err);
     } finally {
       running = false;
@@ -207,6 +226,7 @@ export function startSyncLoop(
 
   function scheduleNext() {
     if (stopped) return;
+    nextSyncAt = Date.now() + intervalMs;
     timer = setTimeout(async () => {
       await cycle();
       scheduleNext();
@@ -214,6 +234,7 @@ export function startSyncLoop(
   }
 
   // Initial delay before first cycle
+  nextSyncAt = Date.now() + INITIAL_DELAY_MS;
   timer = setTimeout(async () => {
     await cycle();
     scheduleNext();
@@ -222,9 +243,21 @@ export function startSyncLoop(
   return {
     stop() {
       stopped = true;
+      nextSyncAt = null;
       if (timer) {
         clearTimeout(timer);
         timer = null;
+      }
+    },
+    getState() {
+      return { lastSyncAt, lastSyncResult, nextSyncAt };
+    },
+    async triggerSync() {
+      await cycle();
+      // Reset the timer so the next scheduled cycle is a full interval away
+      if (!stopped && timer) {
+        clearTimeout(timer);
+        scheduleNext();
       }
     },
   };


### PR DESCRIPTION
Closes #64

### Summary
Add status/sync API routes to the Apple Notes plugin, wire plugin route mounting in core-api, add kore sync CLI command, and create integration tests against the real test database.
