### PR TITLE
feat: CON-001 Extend shared types and consolidation tracker

### DIFF
--- a/apps/core-api/src/app.ts
+++ b/apps/core-api/src/app.ts
@@ -54,6 +54,7 @@ const TYPE_DIRS: Record<string, string> = {
   media: "media",
   note: "notes",
   person: "people",
+  insight: "insights",
 };
 
 export async function ensureDataDirectories(dataPath: string): Promise<void> {

--- a/apps/core-api/src/consolidation-tracker.test.ts
+++ b/apps/core-api/src/consolidation-tracker.test.ts
@@ -1,0 +1,436 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { join } from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { ConsolidationTracker } from "./consolidation-tracker";
+import {
+  InsightFrontmatterSchema,
+  InsightOutputSchema,
+  InsightTypeEnum,
+  InsightStatusEnum,
+  BaseFrontmatterSchema,
+} from "@kore/shared-types";
+
+// ─── Zod Schema Tests ─────────────────────────────────────────────────
+
+describe("InsightFrontmatterSchema", () => {
+  const validInsight = {
+    id: "ins-abc12345",
+    type: "insight" as const,
+    category: "qmd://tech/programming/react",
+    date_saved: "2026-03-14T02:00:00Z",
+    source: "kore_synthesis" as const,
+    tags: ["react", "state-management"],
+    insight_type: "evolution" as const,
+    source_ids: ["abc-123", "def-456"],
+    supersedes: [],
+    superseded_by: [],
+    confidence: 0.82,
+    status: "active" as const,
+    reinforcement_count: 0,
+    re_eval_reason: null,
+    last_synthesized_at: "2026-03-14T02:00:00Z",
+  };
+
+  test("accepts valid insight frontmatter", () => {
+    const result = InsightFrontmatterSchema.safeParse(validInsight);
+    expect(result.success).toBe(true);
+  });
+
+  test("applies defaults for status, reinforcement_count, re_eval_reason", () => {
+    const { status, reinforcement_count, re_eval_reason, ...minimal } = validInsight;
+    const result = InsightFrontmatterSchema.parse(minimal);
+    expect(result.status).toBe("active");
+    expect(result.reinforcement_count).toBe(0);
+    expect(result.re_eval_reason).toBeNull();
+  });
+
+  test("rejects invalid type (must be literal 'insight')", () => {
+    const result = InsightFrontmatterSchema.safeParse({ ...validInsight, type: "note" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid source (must be literal 'kore_synthesis')", () => {
+    const result = InsightFrontmatterSchema.safeParse({ ...validInsight, source: "apple_notes" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects confidence out of range", () => {
+    expect(InsightFrontmatterSchema.safeParse({ ...validInsight, confidence: 1.5 }).success).toBe(false);
+    expect(InsightFrontmatterSchema.safeParse({ ...validInsight, confidence: -0.1 }).success).toBe(false);
+  });
+
+  test("rejects invalid insight_type", () => {
+    const result = InsightFrontmatterSchema.safeParse({ ...validInsight, insight_type: "unknown" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid status", () => {
+    const result = InsightFrontmatterSchema.safeParse({ ...validInsight, status: "unknown" });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects more than 5 tags", () => {
+    const result = InsightFrontmatterSchema.safeParse({
+      ...validInsight,
+      tags: ["a", "b", "c", "d", "e", "f"],
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("InsightOutputSchema", () => {
+  const validOutput = {
+    title: "React State Management Evolution",
+    insight_type: "evolution" as const,
+    synthesis: "Over time, the user has shifted from Redux to Zustand for state management.",
+    connections: [
+      { source_id: "abc-123", target_id: "def-456", relationship: "evolved_from" },
+    ],
+    distilled_items: ["User prefers Zustand over Redux", "Migration happened in Q1 2026"],
+    tags: ["react", "state-management"],
+  };
+
+  test("accepts valid output", () => {
+    const result = InsightOutputSchema.safeParse(validOutput);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects empty distilled_items", () => {
+    const result = InsightOutputSchema.safeParse({ ...validOutput, distilled_items: [] });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects more than 7 distilled_items", () => {
+    const result = InsightOutputSchema.safeParse({
+      ...validOutput,
+      distilled_items: ["a", "b", "c", "d", "e", "f", "g", "h"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty tags", () => {
+    const result = InsightOutputSchema.safeParse({ ...validOutput, tags: [] });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects more than 5 tags", () => {
+    const result = InsightOutputSchema.safeParse({
+      ...validOutput,
+      tags: ["a", "b", "c", "d", "e", "f"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("allows contradiction insight_type from LLM override", () => {
+    const result = InsightOutputSchema.safeParse({ ...validOutput, insight_type: "contradiction" });
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing required fields", () => {
+    expect(InsightOutputSchema.safeParse({ title: "x" }).success).toBe(false);
+    expect(InsightOutputSchema.safeParse({}).success).toBe(false);
+  });
+});
+
+describe("InsightTypeEnum", () => {
+  test("accepts all valid types", () => {
+    for (const t of ["cluster_summary", "evolution", "contradiction", "connection"]) {
+      expect(InsightTypeEnum.safeParse(t).success).toBe(true);
+    }
+  });
+
+  test("rejects invalid type", () => {
+    expect(InsightTypeEnum.safeParse("unknown").success).toBe(false);
+  });
+});
+
+describe("InsightStatusEnum", () => {
+  test("accepts all valid statuses", () => {
+    for (const s of ["active", "evolving", "degraded", "retired", "failed"]) {
+      expect(InsightStatusEnum.safeParse(s).success).toBe(true);
+    }
+  });
+});
+
+describe("BaseFrontmatterSchema consolidation extensions", () => {
+  const validBase = {
+    id: "550e8400-e29b-41d4-a716-446655440000",
+    type: "note" as const,
+    category: "qmd://tech/programming",
+    date_saved: "2026-03-14T02:00:00Z",
+    source: "apple_notes",
+    tags: ["react"],
+  };
+
+  test("accepts consolidated_at and insight_refs", () => {
+    const result = BaseFrontmatterSchema.safeParse({
+      ...validBase,
+      consolidated_at: "2026-03-15T00:00:00Z",
+      insight_refs: ["ins-abc12345"],
+    });
+    expect(result.success).toBe(true);
+  });
+
+  test("consolidated_at and insight_refs are optional", () => {
+    const result = BaseFrontmatterSchema.safeParse(validBase);
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── ConsolidationTracker Tests ───────────────────────────────────────
+
+let tempDir: string;
+let db: Database;
+let tracker: ConsolidationTracker;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "kore-tracker-test-"));
+  db = new Database(join(tempDir, `tracker-${Date.now()}.db`));
+  db.exec("PRAGMA journal_mode = WAL;");
+  db.exec("PRAGMA busy_timeout = 5000;");
+  tracker = new ConsolidationTracker(db);
+});
+
+afterEach(async () => {
+  db.close();
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe("upsertMemory", () => {
+  test("inserts a new memory with pending status", () => {
+    tracker.upsertMemory("mem-1", "note");
+    const row = tracker.getStatus("mem-1");
+    expect(row).not.toBeNull();
+    expect(row!.status).toBe("pending");
+    expect(row!.memory_type).toBe("note");
+    expect(row!.synthesis_attempts).toBe(0);
+    expect(row!.consolidated_at).toBeNull();
+  });
+
+  test("is idempotent — does not overwrite existing row", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.markConsolidated("mem-1");
+    tracker.upsertMemory("mem-1", "note"); // should be no-op
+    const row = tracker.getStatus("mem-1");
+    expect(row!.status).toBe("active");
+  });
+});
+
+describe("markConsolidated", () => {
+  test("sets status to active and consolidated_at", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.markConsolidated("mem-1");
+    const row = tracker.getStatus("mem-1");
+    expect(row!.status).toBe("active");
+    expect(row!.consolidated_at).not.toBeNull();
+  });
+});
+
+describe("markFailed", () => {
+  test("increments synthesis_attempts", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.markFailed("mem-1");
+    const row = tracker.getStatus("mem-1");
+    expect(row!.synthesis_attempts).toBe(1);
+    expect(row!.status).toBe("pending"); // not yet at max
+  });
+
+  test("sets status to failed after reaching maxSynthesisAttempts", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.markFailed("mem-1", 3);
+    tracker.markFailed("mem-1", 3);
+    tracker.markFailed("mem-1", 3);
+    const row = tracker.getStatus("mem-1");
+    expect(row!.synthesis_attempts).toBe(3);
+    expect(row!.status).toBe("failed");
+  });
+
+  test("sets last_attempted_at", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.markFailed("mem-1");
+    const row = tracker.getStatus("mem-1");
+    expect(row!.last_attempted_at).not.toBeNull();
+  });
+});
+
+describe("markEvolving", () => {
+  test("sets status and reason", () => {
+    tracker.upsertMemory("ins-1", "insight");
+    tracker.markEvolving("ins-1", "new_evidence");
+    const row = tracker.getStatus("ins-1");
+    expect(row!.status).toBe("evolving");
+    expect(row!.re_eval_reason).toBe("new_evidence");
+  });
+});
+
+describe("markDegraded", () => {
+  test("sets status to degraded", () => {
+    tracker.upsertMemory("ins-1", "insight");
+    tracker.markDegraded("ins-1");
+    expect(tracker.getStatus("ins-1")!.status).toBe("degraded");
+  });
+});
+
+describe("markRetired", () => {
+  test("sets status to retired", () => {
+    tracker.upsertMemory("ins-1", "insight");
+    tracker.markRetired("ins-1");
+    expect(tracker.getStatus("ins-1")!.status).toBe("retired");
+  });
+});
+
+describe("selectSeed", () => {
+  test("returns re-eval seed (evolving insight) before pending memories", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.upsertMemory("ins-1", "insight");
+    tracker.markEvolving("ins-1", "new_evidence");
+
+    const result = tracker.selectSeed();
+    expect(result).not.toBeNull();
+    expect(result!.memoryId).toBe("ins-1");
+    expect(result!.isReeval).toBe(true);
+  });
+
+  test("returns degraded insight as re-eval seed", () => {
+    tracker.upsertMemory("ins-1", "insight");
+    tracker.markDegraded("ins-1");
+
+    const result = tracker.selectSeed();
+    expect(result).not.toBeNull();
+    expect(result!.memoryId).toBe("ins-1");
+    expect(result!.isReeval).toBe(true);
+  });
+
+  test("returns pending non-insight memory when no re-eval work", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.upsertMemory("mem-2", "place");
+
+    const result = tracker.selectSeed();
+    expect(result).not.toBeNull();
+    expect(result!.isReeval).toBe(false);
+  });
+
+  test("returns null when no seeds available", () => {
+    const result = tracker.selectSeed();
+    expect(result).toBeNull();
+  });
+
+  test("skips failed memories", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.markFailed("mem-1", 1); // will fail on first attempt
+
+    const result = tracker.selectSeed(7, 1); // maxAttempts=1
+    expect(result).toBeNull();
+  });
+
+  test("skips retired memories", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.markRetired("mem-1");
+
+    const result = tracker.selectSeed();
+    expect(result).toBeNull();
+  });
+
+  test("respects cooldown window for previously consolidated memories", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.markConsolidated("mem-1");
+
+    // With a very large cooldown, the recently consolidated memory should not be selected
+    const result = tracker.selectSeed(999);
+    expect(result).toBeNull();
+  });
+
+  test("selects never-consolidated before previously consolidated", () => {
+    tracker.upsertMemory("mem-old", "note");
+    tracker.markConsolidated("mem-old");
+
+    // Set consolidated_at far in the past so cooldown is satisfied
+    db.run(
+      `UPDATE consolidation_tracker SET consolidated_at = datetime('now', '-30 days') WHERE memory_id = 'mem-old'`
+    );
+
+    tracker.upsertMemory("mem-new", "note");
+
+    const result = tracker.selectSeed(7);
+    expect(result).not.toBeNull();
+    expect(result!.memoryId).toBe("mem-new"); // never-consolidated first
+  });
+
+  test("skips re-eval insights that exceeded maxSynthesisAttempts", () => {
+    tracker.upsertMemory("ins-1", "insight");
+    tracker.markEvolving("ins-1", "new_evidence");
+    // Exhaust attempts
+    tracker.markFailed("ins-1", 3);
+    tracker.markFailed("ins-1", 3);
+    tracker.markFailed("ins-1", 3);
+
+    // ins-1 is now 'failed', not in re-eval queue
+    tracker.upsertMemory("mem-1", "note");
+    const result = tracker.selectSeed();
+    expect(result).not.toBeNull();
+    expect(result!.memoryId).toBe("mem-1");
+    expect(result!.isReeval).toBe(false);
+  });
+});
+
+describe("resetFailed", () => {
+  test("resets all failed rows to pending with zero attempts", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.upsertMemory("mem-2", "note");
+    // Fail both until they reach 'failed' status
+    for (let i = 0; i < 3; i++) {
+      tracker.markFailed("mem-1", 3);
+      tracker.markFailed("mem-2", 3);
+    }
+    expect(tracker.getStatus("mem-1")!.status).toBe("failed");
+    expect(tracker.getStatus("mem-2")!.status).toBe("failed");
+
+    tracker.resetFailed();
+
+    expect(tracker.getStatus("mem-1")!.status).toBe("pending");
+    expect(tracker.getStatus("mem-1")!.synthesis_attempts).toBe(0);
+    expect(tracker.getStatus("mem-2")!.status).toBe("pending");
+    expect(tracker.getStatus("mem-2")!.synthesis_attempts).toBe(0);
+  });
+
+  test("does not affect non-failed rows", () => {
+    tracker.upsertMemory("mem-ok", "note");
+    tracker.markConsolidated("mem-ok");
+    tracker.upsertMemory("mem-fail", "note");
+    for (let i = 0; i < 3; i++) tracker.markFailed("mem-fail", 3);
+
+    tracker.resetFailed();
+
+    expect(tracker.getStatus("mem-ok")!.status).toBe("active");
+    expect(tracker.getStatus("mem-fail")!.status).toBe("pending");
+  });
+});
+
+describe("truncateAll", () => {
+  test("deletes all rows", () => {
+    tracker.upsertMemory("mem-1", "note");
+    tracker.upsertMemory("mem-2", "place");
+    tracker.truncateAll();
+    expect(tracker.getStatus("mem-1")).toBeNull();
+    expect(tracker.getStatus("mem-2")).toBeNull();
+  });
+});
+
+describe("getStatus", () => {
+  test("returns null for non-existent id", () => {
+    expect(tracker.getStatus("nonexistent")).toBeNull();
+  });
+
+  test("returns full row", () => {
+    tracker.upsertMemory("mem-1", "note");
+    const row = tracker.getStatus("mem-1");
+    expect(row).toMatchObject({
+      memory_id: "mem-1",
+      memory_type: "note",
+      status: "pending",
+      synthesis_attempts: 0,
+    });
+  });
+});

--- a/apps/core-api/src/consolidation-tracker.ts
+++ b/apps/core-api/src/consolidation-tracker.ts
@@ -1,0 +1,181 @@
+import type { Database } from "bun:sqlite";
+
+export interface TrackerRow {
+  memory_id: string;
+  memory_type: string;
+  consolidated_at: string | null;
+  status: string;
+  re_eval_reason: string | null;
+  synthesis_attempts: number;
+  last_attempted_at: string | null;
+  updated_at: string;
+}
+
+export interface SeedResult {
+  memoryId: string;
+  isReeval: boolean;
+}
+
+const DEFAULT_COOLDOWN_DAYS = 7;
+const DEFAULT_MAX_SYNTHESIS_ATTEMPTS = 3;
+
+/**
+ * SQLite-backed tracker for the consolidation pipeline.
+ * Manages lifecycle state for memories and insights in the consolidation process.
+ */
+export class ConsolidationTracker {
+  private db: Database;
+
+  constructor(db: Database) {
+    this.db = db;
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS consolidation_tracker (
+        memory_id TEXT PRIMARY KEY,
+        memory_type TEXT NOT NULL,
+        consolidated_at DATETIME,
+        status TEXT DEFAULT 'pending',
+        re_eval_reason TEXT,
+        synthesis_attempts INTEGER DEFAULT 0,
+        last_attempted_at DATETIME,
+        updated_at DATETIME DEFAULT (datetime('now'))
+      );
+      CREATE INDEX IF NOT EXISTS idx_consolidation_status ON consolidation_tracker(status);
+      CREATE INDEX IF NOT EXISTS idx_consolidation_pending ON consolidation_tracker(consolidated_at, memory_type)
+        WHERE status = 'pending' AND memory_type != 'insight';
+    `);
+  }
+
+  /** Insert with status='pending' if not exists, no-op if exists. */
+  upsertMemory(id: string, type: string): void {
+    this.db.run(
+      `INSERT INTO consolidation_tracker (memory_id, memory_type, status, updated_at)
+       VALUES (?, ?, 'pending', datetime('now'))
+       ON CONFLICT(memory_id) DO NOTHING`,
+      [id, type]
+    );
+  }
+
+  /** Set status='active', consolidated_at=now(). */
+  markConsolidated(id: string, _insightId?: string): void {
+    this.db.run(
+      `UPDATE consolidation_tracker
+       SET status = 'active', consolidated_at = datetime('now'), updated_at = datetime('now')
+       WHERE memory_id = ?`,
+      [id]
+    );
+  }
+
+  /** Increment synthesis_attempts, set last_attempted_at=now(), set status='failed' if >= maxSynthesisAttempts. */
+  markFailed(id: string, maxSynthesisAttempts: number = DEFAULT_MAX_SYNTHESIS_ATTEMPTS): void {
+    const row = this.db.query(
+      `SELECT synthesis_attempts FROM consolidation_tracker WHERE memory_id = ?`
+    ).get(id) as { synthesis_attempts: number } | null;
+
+    if (!row) return;
+
+    const newAttempts = row.synthesis_attempts + 1;
+    const newStatus = newAttempts >= maxSynthesisAttempts ? "failed" : "pending";
+
+    this.db.run(
+      `UPDATE consolidation_tracker
+       SET synthesis_attempts = ?, last_attempted_at = datetime('now'), status = ?, updated_at = datetime('now')
+       WHERE memory_id = ?`,
+      [newAttempts, newStatus, id]
+    );
+  }
+
+  /** Set status='evolving', re_eval_reason. */
+  markEvolving(id: string, reason: "new_evidence" | "source_deleted"): void {
+    this.db.run(
+      `UPDATE consolidation_tracker
+       SET status = 'evolving', re_eval_reason = ?, updated_at = datetime('now')
+       WHERE memory_id = ?`,
+      [reason, id]
+    );
+  }
+
+  /** Set status='degraded'. */
+  markDegraded(id: string): void {
+    this.db.run(
+      `UPDATE consolidation_tracker
+       SET status = 'degraded', updated_at = datetime('now')
+       WHERE memory_id = ?`,
+      [id]
+    );
+  }
+
+  /** Set status='retired'. */
+  markRetired(id: string): void {
+    this.db.run(
+      `UPDATE consolidation_tracker
+       SET status = 'retired', updated_at = datetime('now')
+       WHERE memory_id = ?`,
+      [id]
+    );
+  }
+
+  /**
+   * Dual-queue seed selection per design doc §10.6:
+   * 1. Re-evaluation queue first (priority): evolving/degraded insights
+   * 2. New seed queue: pending non-insight memories respecting cooldown
+   */
+  selectSeed(
+    cooldownDays: number = DEFAULT_COOLDOWN_DAYS,
+    maxSynthesisAttempts: number = DEFAULT_MAX_SYNTHESIS_ATTEMPTS
+  ): SeedResult | null {
+    // 1. Re-evaluation queue first
+    const reeval = this.db.query(`
+      SELECT memory_id FROM consolidation_tracker
+      WHERE memory_type = 'insight'
+        AND status IN ('evolving', 'degraded')
+        AND synthesis_attempts < ?
+      ORDER BY updated_at ASC
+      LIMIT 1
+    `).get(maxSynthesisAttempts) as { memory_id: string } | null;
+
+    if (reeval) {
+      return { memoryId: reeval.memory_id, isReeval: true };
+    }
+
+    // 2. New seed queue
+    const cooldownParam = `-${cooldownDays} days`;
+    const seed = this.db.query(`
+      SELECT memory_id FROM consolidation_tracker
+      WHERE memory_type != 'insight'
+        AND status NOT IN ('failed', 'retired')
+        AND synthesis_attempts < ?
+        AND (consolidated_at IS NULL OR consolidated_at < datetime('now', ?))
+      ORDER BY
+        CASE WHEN consolidated_at IS NULL THEN 0 ELSE 1 END,
+        consolidated_at ASC
+      LIMIT 1
+    `).get(maxSynthesisAttempts, cooldownParam) as { memory_id: string } | null;
+
+    if (seed) {
+      return { memoryId: seed.memory_id, isReeval: false };
+    }
+
+    return null;
+  }
+
+  /** Return current tracker row or null. */
+  getStatus(id: string): TrackerRow | null {
+    return this.db.query(
+      `SELECT * FROM consolidation_tracker WHERE memory_id = ?`
+    ).get(id) as TrackerRow | null;
+  }
+
+  /** Set all 'failed' rows back to 'pending', reset synthesis_attempts to 0. */
+  resetFailed(): void {
+    this.db.run(
+      `UPDATE consolidation_tracker
+       SET status = 'pending', synthesis_attempts = 0, updated_at = datetime('now')
+       WHERE status = 'failed'`
+    );
+  }
+
+  /** Delete all rows (used by reset command). */
+  truncateAll(): void {
+    this.db.run("DELETE FROM consolidation_tracker");
+  }
+}

--- a/apps/core-api/src/memory-index.ts
+++ b/apps/core-api/src/memory-index.ts
@@ -1,7 +1,7 @@
 import { readdir, readFile } from "node:fs/promises";
 import { join } from "node:path";
 
-const TYPE_DIRS = ["places", "media", "notes", "people"];
+const TYPE_DIRS = ["places", "media", "notes", "people", "insights"];
 
 /**
  * In-memory Map<id, filePath> index built by scanning all .md files

--- a/apps/core-api/src/worker.ts
+++ b/apps/core-api/src/worker.ts
@@ -13,6 +13,7 @@ const TYPE_DIRS: Record<string, string> = {
   media: "media",
   note: "notes",
   person: "people",
+  insight: "insights",
 };
 
 const DEFAULT_POLL_INTERVAL_MS = 5_000;

--- a/packages/shared-types/index.ts
+++ b/packages/shared-types/index.ts
@@ -3,7 +3,7 @@ import type { Elysia } from "elysia";
 
 // ─── Zod Schemas (data_schema.md §3.1) ─────────────────────────────
 
-export const MemoryTypeEnum = z.enum(["place", "media", "note", "person"]);
+export const MemoryTypeEnum = z.enum(["place", "media", "note", "person", "insight"]);
 export type MemoryType = z.infer<typeof MemoryTypeEnum>;
 
 export const IntentEnum = z.enum(["recommendation", "reference", "personal-experience", "aspiration", "how-to"]);
@@ -42,9 +42,56 @@ export const BaseFrontmatterSchema = z.object({
 
   /** LLM extraction confidence score (0–1) */
   confidence: z.number().min(0).max(1).optional(),
+
+  /** ISO timestamp — added to source memories after consolidation */
+  consolidated_at: z.string().datetime().optional(),
+
+  /** Insight IDs that reference this source memory */
+  insight_refs: z.array(z.string()).optional(),
 });
 
 export type BaseFrontmatter = z.infer<typeof BaseFrontmatterSchema>;
+
+// ─── Insight Schemas (consolidation_system_design.md §3.2, §5.4, §10.7) ─
+
+export const InsightTypeEnum = z.enum(["cluster_summary", "evolution", "contradiction", "connection"]);
+export type InsightType = z.infer<typeof InsightTypeEnum>;
+
+export const InsightStatusEnum = z.enum(["active", "evolving", "degraded", "retired", "failed"]);
+export type InsightStatus = z.infer<typeof InsightStatusEnum>;
+
+export const InsightFrontmatterSchema = z.object({
+  id: z.string(),
+  type: z.literal("insight"),
+  category: z.string().startsWith("qmd://"),
+  date_saved: z.string().datetime(),
+  source: z.literal("kore_synthesis"),
+  tags: z.array(z.string()).max(5),
+  insight_type: InsightTypeEnum,
+  source_ids: z.array(z.string()),
+  supersedes: z.array(z.string()),
+  superseded_by: z.array(z.string()),
+  confidence: z.number().min(0).max(1),
+  status: InsightStatusEnum.default("active"),
+  reinforcement_count: z.number().default(0),
+  re_eval_reason: z.enum(["new_evidence", "source_deleted"]).nullable().default(null),
+  last_synthesized_at: z.string().datetime(),
+});
+export type InsightFrontmatter = z.infer<typeof InsightFrontmatterSchema>;
+
+export const InsightOutputSchema = z.object({
+  title: z.string(),
+  insight_type: InsightTypeEnum,
+  synthesis: z.string(),
+  connections: z.array(z.object({
+    source_id: z.string(),
+    target_id: z.string(),
+    relationship: z.string(),
+  })),
+  distilled_items: z.array(z.string()).min(1).max(7),
+  tags: z.array(z.string()).min(1).max(5),
+});
+export type InsightOutput = z.infer<typeof InsightOutputSchema>;
 
 // ─── LLM Extraction Schema (data_schema.md §3.2) ───────────────────
 


### PR DESCRIPTION
## Summary
- Extended `MemoryTypeEnum` with `"insight"` and added `InsightTypeEnum`, `InsightStatusEnum`, `InsightFrontmatterSchema`, and `InsightOutputSchema` to `@kore/shared-types`
- Extended `BaseFrontmatterSchema` with optional `consolidated_at` and `insight_refs` fields for source memory back-references
- Created `ConsolidationTracker` class with SQLite-backed lifecycle management: dual-queue seed selection, upsert, mark consolidated/failed/evolving/degraded/retired, resetFailed, truncateAll
- Updated `TYPE_DIRS` in `worker.ts`, `app.ts`, and `memory-index.ts` to include `insight: "insights"`
- 43 unit tests covering Zod schema validation and all tracker operations

## Test plan
- [x] `bun tsc --noEmit` passes across the monorepo
- [x] 43 new unit tests pass for Zod schemas and ConsolidationTracker
- [x] All 187 existing tests continue to pass
- [ ] `MemoryExtractionSchema.type` remains unchanged (no `"insight"`)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)