### PR TITLE
feat: Candidate finder, cluster analyzer, and LLM synthesis engine (CON-002)

### DIFF
--- a/apps/core-api/src/consolidation-candidate-finder.test.ts
+++ b/apps/core-api/src/consolidation-candidate-finder.test.ts
@@ -1,0 +1,218 @@
+import { describe, test, expect } from "bun:test";
+import {
+  buildConsolidationQuery,
+  findCandidates,
+  validateCluster,
+  classifyCluster,
+} from "./consolidation-candidate-finder";
+import type { SeedMemory, CandidateResult } from "./consolidation-candidate-finder";
+import type { HybridQueryResult } from "@kore/qmd-client";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function makeSeed(overrides: Partial<SeedMemory> = {}): SeedMemory {
+  return {
+    id: "seed-001",
+    title: "React State Management",
+    type: "note",
+    category: "qmd://tech/programming/react",
+    date_saved: "2026-01-15T00:00:00Z",
+    distilledItems: [
+      "useState is the simplest React hook for local state.",
+      "useReducer is better for complex state logic.",
+      "Context API avoids prop drilling.",
+      "Redux is overkill for small apps.",
+    ],
+    filePath: "/data/notes/react-state.md",
+    ...overrides,
+  };
+}
+
+function makeCandidate(overrides: Partial<CandidateResult> = {}): CandidateResult {
+  return {
+    memoryId: "cand-001",
+    filePath: "/data/notes/cand.md",
+    score: 0.72,
+    frontmatter: {},
+    ...overrides,
+  };
+}
+
+// ─── Query Construction ──────────────────────────────────────────────
+
+describe("buildConsolidationQuery", () => {
+  test("constructs query from title + first 3 distilled items", () => {
+    const seed = makeSeed();
+    const query = buildConsolidationQuery(seed);
+    expect(query).toBe(
+      "React State Management. useState is the simplest React hook for local state.. useReducer is better for complex state logic.. Context API avoids prop drilling."
+    );
+  });
+
+  test("handles seed with fewer than 3 distilled items", () => {
+    const seed = makeSeed({ distilledItems: ["Single fact."] });
+    const query = buildConsolidationQuery(seed);
+    expect(query).toBe("React State Management. Single fact.");
+  });
+
+  test("handles seed with no distilled items", () => {
+    const seed = makeSeed({ distilledItems: [] });
+    const query = buildConsolidationQuery(seed);
+    expect(query).toBe("React State Management. ");
+  });
+});
+
+// ─── findCandidates ──────────────────────────────────────────────────
+
+describe("findCandidates", () => {
+  test("excludes seed from results by file path", async () => {
+    const seed = makeSeed();
+    const mockSearch = async () => [
+      { file: "/data/notes/react-state.md", title: "Same file", score: 1.0, bestChunk: "" },
+      { file: "/data/notes/other.md", title: "Other", score: 0.8, bestChunk: "" },
+    ] as HybridQueryResult[];
+
+    const results = await findCandidates(seed, mockSearch);
+    expect(results).toHaveLength(1);
+    expect(results[0].filePath).toBe("/data/notes/other.md");
+  });
+
+  test("excludes insight-type memories", async () => {
+    const seed = makeSeed();
+    const mockSearch = async () => [
+      { file: "/data/insights/ins-abc.md", title: "Insight", score: 0.9, bestChunk: "" },
+      { file: "/data/notes/other.md", title: "Other", score: 0.7, bestChunk: "" },
+    ] as HybridQueryResult[];
+
+    const results = await findCandidates(seed, mockSearch);
+    expect(results).toHaveLength(1);
+    expect(results[0].filePath).toBe("/data/notes/other.md");
+  });
+
+  test("passes correct search options", async () => {
+    const seed = makeSeed();
+    let capturedOptions: any;
+    const mockSearch = async (_q: string, opts?: any) => {
+      capturedOptions = opts;
+      return [];
+    };
+
+    await findCandidates(seed, mockSearch, { maxClusterSize: 5, minSimilarityScore: 0.6 });
+
+    expect(capturedOptions.limit).toBe(10); // maxClusterSize + 5
+    expect(capturedOptions.collection).toBe("memories");
+    expect(capturedOptions.intent).toContain("knowledge consolidation");
+    expect(capturedOptions.minScore).toBe(0.6);
+  });
+});
+
+// ─── validateCluster ─────────────────────────────────────────────────
+
+describe("validateCluster", () => {
+  test("returns invalid when cluster too small (seed + 1 < 3)", () => {
+    const seed = makeSeed();
+    const candidates = [makeCandidate()];
+    const result = validateCluster(seed, candidates);
+    expect(result.valid).toBe(false);
+    if (!result.valid) {
+      expect(result.reason).toContain("below minimum");
+    }
+  });
+
+  test("returns valid for exact minimum size (seed + 2 = 3)", () => {
+    const seed = makeSeed();
+    const candidates = [makeCandidate(), makeCandidate({ memoryId: "cand-002" })];
+    const result = validateCluster(seed, candidates);
+    expect(result.valid).toBe(true);
+  });
+
+  test("returns valid for maximum size (seed + 7 = 8)", () => {
+    const seed = makeSeed();
+    const candidates = Array.from({ length: 7 }, (_, i) =>
+      makeCandidate({ memoryId: `cand-${i}`, score: 0.9 - i * 0.05 })
+    );
+    const result = validateCluster(seed, candidates);
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.cluster).toHaveLength(7);
+    }
+  });
+
+  test("truncates to top-scoring when over maxClusterSize", () => {
+    const seed = makeSeed();
+    const candidates = Array.from({ length: 10 }, (_, i) =>
+      makeCandidate({ memoryId: `cand-${i}`, score: 0.5 + i * 0.05 })
+    );
+    const result = validateCluster(seed, candidates, { maxClusterSize: 5 });
+    expect(result.valid).toBe(true);
+    if (result.valid) {
+      expect(result.cluster).toHaveLength(4); // maxClusterSize(5) - 1(seed) = 4
+      // Should be top-scoring
+      expect(result.cluster[0].score).toBeGreaterThanOrEqual(result.cluster[1].score);
+    }
+  });
+
+  test("returns invalid when no candidates at all", () => {
+    const seed = makeSeed();
+    const result = validateCluster(seed, []);
+    expect(result.valid).toBe(false);
+  });
+});
+
+// ─── classifyCluster ─────────────────────────────────────────────────
+
+describe("classifyCluster", () => {
+  test("returns 'connection' when categories differ", () => {
+    const cluster = [
+      { category: "qmd://tech/react", type: "note", date_saved: "2026-01-01T00:00:00Z" },
+      { category: "qmd://personal/goals", type: "note", date_saved: "2026-01-02T00:00:00Z" },
+      { category: "qmd://tech/react", type: "note", date_saved: "2026-01-03T00:00:00Z" },
+    ];
+    expect(classifyCluster(cluster)).toBe("connection");
+  });
+
+  test("returns 'connection' when types differ", () => {
+    const cluster = [
+      { category: "qmd://tech", type: "note", date_saved: "2026-01-01T00:00:00Z" },
+      { category: "qmd://tech", type: "person", date_saved: "2026-01-02T00:00:00Z" },
+      { category: "qmd://tech", type: "note", date_saved: "2026-01-03T00:00:00Z" },
+    ];
+    expect(classifyCluster(cluster)).toBe("connection");
+  });
+
+  test("returns 'evolution' when span > 30 days with same category", () => {
+    const cluster = [
+      { category: "qmd://tech", type: "note", date_saved: "2025-12-01T00:00:00Z" },
+      { category: "qmd://tech", type: "note", date_saved: "2026-02-15T00:00:00Z" },
+      { category: "qmd://tech", type: "note", date_saved: "2026-01-10T00:00:00Z" },
+    ];
+    expect(classifyCluster(cluster)).toBe("evolution");
+  });
+
+  test("returns 'cluster_summary' for same category, same type, span <= 30 days", () => {
+    const cluster = [
+      { category: "qmd://tech", type: "note", date_saved: "2026-01-01T00:00:00Z" },
+      { category: "qmd://tech", type: "note", date_saved: "2026-01-15T00:00:00Z" },
+      { category: "qmd://tech", type: "note", date_saved: "2026-01-20T00:00:00Z" },
+    ];
+    expect(classifyCluster(cluster)).toBe("cluster_summary");
+  });
+
+  test("returns 'cluster_summary' when no dates available", () => {
+    const cluster = [
+      { category: "qmd://tech", type: "note" },
+      { category: "qmd://tech", type: "note" },
+      { category: "qmd://tech", type: "note" },
+    ];
+    expect(classifyCluster(cluster)).toBe("cluster_summary");
+  });
+
+  test("connection takes priority over evolution (cross-category + span > 30)", () => {
+    const cluster = [
+      { category: "qmd://tech", type: "note", date_saved: "2025-01-01T00:00:00Z" },
+      { category: "qmd://personal", type: "note", date_saved: "2026-03-01T00:00:00Z" },
+      { category: "qmd://tech", type: "note", date_saved: "2026-02-01T00:00:00Z" },
+    ];
+    expect(classifyCluster(cluster)).toBe("connection");
+  });
+});

--- a/apps/core-api/src/consolidation-candidate-finder.ts
+++ b/apps/core-api/src/consolidation-candidate-finder.ts
@@ -1,0 +1,155 @@
+import type { HybridQueryResult, SearchOptions } from "@kore/qmd-client";
+import type { InsightType } from "@kore/shared-types";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export interface CandidateResult {
+  memoryId: string;
+  filePath: string;
+  score: number;
+  frontmatter: Record<string, any>;
+}
+
+export type ClusterValidation =
+  | { valid: true; cluster: CandidateResult[] }
+  | { valid: false; reason: string };
+
+export interface CandidateFinderOptions {
+  minClusterSize?: number;  // default: 3
+  maxClusterSize?: number;  // default: 8
+  minSimilarityScore?: number;  // default: 0.45
+}
+
+export interface SeedMemory {
+  id: string;
+  title: string;
+  type: string;
+  category: string;
+  date_saved: string;
+  distilledItems: string[];
+  filePath: string;
+}
+
+type QmdSearchFn = (query: string, options?: SearchOptions) => Promise<HybridQueryResult[]>;
+
+// ─── Candidate Finder ────────────────────────────────────────────────
+
+/**
+ * Build a consolidation query from seed title + first 3 distilled items (design doc §4.4).
+ */
+export function buildConsolidationQuery(seed: SeedMemory): string {
+  const items = seed.distilledItems.slice(0, 3).join(". ");
+  return `${seed.title}. ${items}`;
+}
+
+/**
+ * Find candidate memories for consolidation with a seed memory via QMD search.
+ */
+export async function findCandidates(
+  seed: SeedMemory,
+  qmdSearch: QmdSearchFn,
+  options: CandidateFinderOptions = {}
+): Promise<CandidateResult[]> {
+  const {
+    maxClusterSize = 8,
+    minSimilarityScore = 0.45,
+  } = options;
+
+  const query = buildConsolidationQuery(seed);
+
+  const results = await qmdSearch(query, {
+    limit: maxClusterSize + 5,
+    collection: "memories",
+    intent: "Find memories related to the same topic, concept, or entity for knowledge consolidation",
+    minScore: minSimilarityScore,
+  });
+
+  return results
+    .filter((r) => {
+      // Exclude the seed itself (match by file path)
+      if (r.file === seed.filePath) return false;
+      // Exclude insight-type memories (no meta-synthesis)
+      if (r.file.includes("/insights/")) return false;
+      return true;
+    })
+    .map((r) => ({
+      memoryId: "", // filled in by caller from memoryIndex
+      filePath: r.file,
+      score: r.score,
+      frontmatter: {},
+    }));
+}
+
+/**
+ * Validate cluster size (seed + candidates must be 3–8).
+ * Truncates to top-scoring if over maxClusterSize rather than rejecting.
+ */
+export function validateCluster(
+  seed: SeedMemory,
+  candidates: CandidateResult[],
+  options: CandidateFinderOptions = {}
+): ClusterValidation {
+  const { minClusterSize = 3, maxClusterSize = 8 } = options;
+
+  const totalSize = 1 + candidates.length; // seed + candidates
+
+  if (totalSize < minClusterSize) {
+    return {
+      valid: false,
+      reason: `Cluster size ${totalSize} is below minimum ${minClusterSize}`,
+    };
+  }
+
+  // Truncate to top-scoring candidates if over max
+  let cluster = candidates;
+  if (totalSize > maxClusterSize) {
+    cluster = candidates
+      .sort((a, b) => b.score - a.score)
+      .slice(0, maxClusterSize - 1); // -1 for seed
+  }
+
+  return { valid: true, cluster };
+}
+
+/**
+ * Deterministic insight type classification (design doc §4.3).
+ *
+ * Rules:
+ * - cross-category OR cross-type → "connection"
+ * - temporal span > 30 days → "evolution"
+ * - else → "cluster_summary"
+ *
+ * "contradiction" is detected by LLM during synthesis, not here.
+ */
+export function classifyCluster(
+  cluster: Array<{ category?: string; type?: string; date_saved?: string }>
+): InsightType {
+  const categories = new Set(
+    cluster.map((m) => m.category).filter(Boolean)
+  );
+  const types = new Set(
+    cluster.map((m) => m.type).filter(Boolean)
+  );
+
+  // Cross-category or cross-type → connection
+  if (categories.size > 1 || types.size > 1) {
+    return "connection";
+  }
+
+  // Temporal span > 30 days → evolution
+  const dates = cluster
+    .map((m) => m.date_saved)
+    .filter(Boolean)
+    .map((d) => new Date(d!).getTime())
+    .filter((t) => !isNaN(t));
+
+  if (dates.length >= 2) {
+    const spanMs = Math.max(...dates) - Math.min(...dates);
+    const spanDays = spanMs / (1000 * 60 * 60 * 24);
+    if (spanDays > 30) {
+      return "evolution";
+    }
+  }
+
+  return "cluster_summary";
+}

--- a/apps/core-api/src/consolidation-synthesizer.test.ts
+++ b/apps/core-api/src/consolidation-synthesizer.test.ts
@@ -1,0 +1,284 @@
+import { describe, test, expect } from "bun:test";
+import {
+  buildSynthesisPrompt,
+  computeInsightConfidence,
+  fallbackParse,
+} from "./consolidation-synthesizer";
+import { InsightOutputSchema } from "@kore/shared-types";
+import type { ClusterMember } from "./consolidation-synthesizer";
+
+// ─── Helpers ─────────────────────────────────────────────────────────
+
+function makeMember(overrides: Partial<ClusterMember> = {}): ClusterMember {
+  return {
+    id: "mem-001",
+    title: "React Hooks",
+    type: "note",
+    category: "qmd://tech/programming/react",
+    date_saved: "2026-01-15T00:00:00Z",
+    tags: ["react", "hooks"],
+    distilledItems: ["useState manages local state.", "useEffect handles side effects."],
+    rawSource: "React hooks are functions that let you use state and lifecycle features in function components.",
+    ...overrides,
+  };
+}
+
+// ─── Prompt Construction ─────────────────────────────────────────────
+
+describe("buildSynthesisPrompt", () => {
+  test("includes insight type header", () => {
+    const prompt = buildSynthesisPrompt([makeMember()], "cluster_summary");
+    expect(prompt).toContain("Insight type requested: cluster_summary");
+  });
+
+  test("includes memory header with ID and date", () => {
+    const prompt = buildSynthesisPrompt([makeMember()], "cluster_summary");
+    expect(prompt).toContain("### Memory 1 (ID: mem-001, saved: 2026-01-15T00:00:00Z)");
+  });
+
+  test("includes title, type, category, and tags", () => {
+    const prompt = buildSynthesisPrompt([makeMember()], "cluster_summary");
+    expect(prompt).toContain("**Title:** React Hooks");
+    expect(prompt).toContain("**Type:** note");
+    expect(prompt).toContain("**Category:** qmd://tech/programming/react");
+    expect(prompt).toContain("**Tags:** react, hooks");
+  });
+
+  test("includes distilled items as facts", () => {
+    const prompt = buildSynthesisPrompt([makeMember()], "cluster_summary");
+    expect(prompt).toContain("- **Facts:**");
+    expect(prompt).toContain("  - useState manages local state.");
+    expect(prompt).toContain("  - useEffect handles side effects.");
+  });
+
+  test("includes source excerpt truncated to 300 chars", () => {
+    const longSource = "x".repeat(500);
+    const prompt = buildSynthesisPrompt(
+      [makeMember({ rawSource: longSource })],
+      "cluster_summary"
+    );
+    expect(prompt).toContain(`"${"x".repeat(300)}..."`);
+  });
+
+  test("does not add ellipsis for short source", () => {
+    const prompt = buildSynthesisPrompt([makeMember()], "cluster_summary");
+    expect(prompt).not.toContain('..."');
+  });
+
+  test("numbers multiple memories sequentially", () => {
+    const members = [
+      makeMember({ id: "a" }),
+      makeMember({ id: "b" }),
+      makeMember({ id: "c" }),
+    ];
+    const prompt = buildSynthesisPrompt(members, "evolution");
+    expect(prompt).toContain("### Memory 1 (ID: a");
+    expect(prompt).toContain("### Memory 2 (ID: b");
+    expect(prompt).toContain("### Memory 3 (ID: c");
+  });
+});
+
+// ─── InsightOutputSchema Validation ──────────────────────────────────
+
+describe("InsightOutputSchema", () => {
+  const validOutput = {
+    title: "React State Management Patterns",
+    insight_type: "cluster_summary" as const,
+    synthesis: "React offers multiple approaches to state management. useState handles simple local state while useReducer manages complex state logic.",
+    connections: [
+      { source_id: "mem-001", target_id: "mem-002", relationship: "both discuss state hooks" },
+    ],
+    distilled_items: ["useState is for simple local state.", "useReducer handles complex state."],
+    tags: ["react", "state-management"],
+  };
+
+  test("accepts valid output", () => {
+    const result = InsightOutputSchema.safeParse(validOutput);
+    expect(result.success).toBe(true);
+  });
+
+  test("rejects missing title", () => {
+    const { title, ...rest } = validOutput;
+    const result = InsightOutputSchema.safeParse(rest);
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects empty distilled_items", () => {
+    const result = InsightOutputSchema.safeParse({ ...validOutput, distilled_items: [] });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects more than 7 distilled_items", () => {
+    const result = InsightOutputSchema.safeParse({
+      ...validOutput,
+      distilled_items: Array.from({ length: 8 }, (_, i) => `Item ${i}`),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects more than 5 tags", () => {
+    const result = InsightOutputSchema.safeParse({
+      ...validOutput,
+      tags: ["a", "b", "c", "d", "e", "f"],
+    });
+    expect(result.success).toBe(false);
+  });
+
+  test("rejects invalid insight_type", () => {
+    const result = InsightOutputSchema.safeParse({ ...validOutput, insight_type: "invalid" });
+    expect(result.success).toBe(false);
+  });
+
+  test("accepts contradiction as insight_type", () => {
+    const result = InsightOutputSchema.safeParse({ ...validOutput, insight_type: "contradiction" });
+    expect(result.success).toBe(true);
+  });
+
+  test("accepts empty connections array", () => {
+    const result = InsightOutputSchema.safeParse({ ...validOutput, connections: [] });
+    expect(result.success).toBe(true);
+  });
+});
+
+// ─── fallbackParse ───────────────────────────────────────────────────
+
+describe("fallbackParse", () => {
+  const validJson = JSON.stringify({
+    title: "Test Insight",
+    insight_type: "cluster_summary",
+    synthesis: "A synthesis paragraph.",
+    connections: [],
+    distilled_items: ["Fact one."],
+    tags: ["test"],
+  });
+
+  test("parses valid JSON", () => {
+    const result = fallbackParse(validJson);
+    expect(result.title).toBe("Test Insight");
+  });
+
+  test("strips markdown code fences", () => {
+    const result = fallbackParse("```json\n" + validJson + "\n```");
+    expect(result.title).toBe("Test Insight");
+  });
+
+  test("normalizes tags to lowercase kebab-case", () => {
+    const json = JSON.stringify({
+      title: "Test",
+      insight_type: "cluster_summary",
+      synthesis: "A synthesis.",
+      connections: [],
+      distilled_items: ["Fact."],
+      tags: ["UPPER_CASE", "with spaces"],
+    });
+    const result = fallbackParse(json);
+    expect(result.tags).toEqual(["upper-case", "with-spaces"]);
+  });
+
+  test("truncates distilled_items to 7", () => {
+    const json = JSON.stringify({
+      title: "Test",
+      insight_type: "cluster_summary",
+      synthesis: "A synthesis.",
+      connections: [],
+      distilled_items: Array.from({ length: 10 }, (_, i) => `Item ${i}`),
+      tags: ["test"],
+    });
+    const result = fallbackParse(json);
+    expect(result.distilled_items).toHaveLength(7);
+  });
+
+  test("throws on non-JSON input", () => {
+    expect(() => fallbackParse("not json at all")).toThrow("no JSON object found");
+  });
+});
+
+// ─── Confidence Scoring ──────────────────────────────────────────────
+
+describe("computeInsightConfidence", () => {
+  test("minimum cluster size (3) with moderate similarity", () => {
+    const conf = computeInsightConfidence({
+      avgSimilarity: 0.6,
+      clusterSize: 3,
+      reinforcementCount: 0,
+      sourceIntegrity: 1.0,
+    });
+    // sizeFactor = min((3-2)/3, 1.0) = 0.333
+    // base = 0.6 * 0.5 + 0.333 * 0.5 = 0.3 + 0.167 = 0.467
+    // adjusted = 0.467 * 1.0 * 1.0 = 0.467 → 0.47
+    expect(conf).toBeCloseTo(0.47, 2);
+  });
+
+  test("maximum cluster size (8) with high similarity", () => {
+    const conf = computeInsightConfidence({
+      avgSimilarity: 0.9,
+      clusterSize: 8,
+      reinforcementCount: 0,
+      sourceIntegrity: 1.0,
+    });
+    // sizeFactor = min((8-2)/3, 1.0) = min(2.0, 1.0) = 1.0
+    // base = 0.9 * 0.5 + 1.0 * 0.5 = 0.45 + 0.5 = 0.95
+    expect(conf).toBeCloseTo(0.95, 2);
+  });
+
+  test("reinforcement boost capped at 1.15", () => {
+    const conf = computeInsightConfidence({
+      avgSimilarity: 0.8,
+      clusterSize: 5,
+      reinforcementCount: 10, // way over cap
+      sourceIntegrity: 1.0,
+    });
+    // sizeFactor = min((5-2)/3, 1.0) = 1.0
+    // base = 0.8 * 0.5 + 1.0 * 0.5 = 0.9
+    // reinforcementFactor = min(1.0 + 10*0.05, 1.15) = 1.15
+    // adjusted = 0.9 * 1.15 * 1.0 = 1.035 → capped at 1.0
+    expect(conf).toBe(1.0);
+  });
+
+  test("partial source integrity reduces confidence", () => {
+    const conf = computeInsightConfidence({
+      avgSimilarity: 0.8,
+      clusterSize: 5,
+      reinforcementCount: 0,
+      sourceIntegrity: 0.5,
+    });
+    // sizeFactor = 1.0
+    // base = 0.8 * 0.5 + 1.0 * 0.5 = 0.9
+    // adjusted = 0.9 * 1.0 * 0.5 = 0.45
+    expect(conf).toBeCloseTo(0.45, 2);
+  });
+
+  test("zero source integrity yields 0.0", () => {
+    const conf = computeInsightConfidence({
+      avgSimilarity: 0.9,
+      clusterSize: 8,
+      reinforcementCount: 3,
+      sourceIntegrity: 0.0,
+    });
+    expect(conf).toBe(0);
+  });
+
+  test("moderate reinforcement (3) adds 15% boost", () => {
+    const conf = computeInsightConfidence({
+      avgSimilarity: 0.7,
+      clusterSize: 4,
+      reinforcementCount: 3,
+      sourceIntegrity: 1.0,
+    });
+    // sizeFactor = min((4-2)/3, 1.0) = 0.667
+    // base = 0.7 * 0.5 + 0.667 * 0.5 = 0.35 + 0.333 = 0.683
+    // reinforcementFactor = min(1.0 + 3*0.05, 1.15) = 1.15
+    // adjusted = 0.683 * 1.15 * 1.0 = 0.786 → 0.79
+    expect(conf).toBeCloseTo(0.79, 2);
+  });
+
+  test("result never exceeds 1.0", () => {
+    const conf = computeInsightConfidence({
+      avgSimilarity: 1.0,
+      clusterSize: 100,
+      reinforcementCount: 100,
+      sourceIntegrity: 1.0,
+    });
+    expect(conf).toBeLessThanOrEqual(1.0);
+  });
+});

--- a/apps/core-api/src/consolidation-synthesizer.ts
+++ b/apps/core-api/src/consolidation-synthesizer.ts
@@ -1,0 +1,208 @@
+import { createOpenAI } from "@ai-sdk/openai";
+import { createGoogleGenerativeAI } from "@ai-sdk/google";
+import { generateText, Output } from "ai";
+import { InsightOutputSchema } from "@kore/shared-types";
+import type { InsightOutput, InsightType } from "@kore/shared-types";
+
+// ─── Types ───────────────────────────────────────────────────────────
+
+export interface ClusterMember {
+  id: string;
+  title: string;
+  type: string;
+  category: string;
+  date_saved: string;
+  tags: string[];
+  distilledItems: string[];
+  rawSource: string;
+}
+
+export interface SynthesisResult extends InsightOutput {
+  _extractionPath: "structured" | "fallback";
+}
+
+// ─── Model Resolution ────────────────────────────────────────────────
+
+/**
+ * Resolve the language model for synthesis.
+ * Uses KORE_SYNTHESIS_MODEL override if set, otherwise falls back to
+ * LLM_PROVIDER/LLM_MODEL (same as llm-extractor).
+ */
+function resolveModel() {
+  const provider = process.env.LLM_PROVIDER || "ollama";
+  const synthesisModel = process.env.KORE_SYNTHESIS_MODEL;
+
+  if (provider === "gemini") {
+    const apiKey = process.env.GEMINI_API_KEY ?? process.env.GOOGLE_GENERATIVE_AI_API_KEY;
+    if (!apiKey) throw new Error("LLM_PROVIDER=gemini requires GEMINI_API_KEY to be set");
+    const modelName = synthesisModel || process.env.LLM_MODEL || "gemini-2.5-flash-lite";
+    return createGoogleGenerativeAI({ apiKey })(modelName);
+  }
+
+  // Default: ollama
+  let baseURL = process.env.OLLAMA_BASE_URL || "http://localhost:11434";
+  if (!baseURL.endsWith("/v1")) baseURL = baseURL.replace(/\/$/, "") + "/v1";
+  const modelName = synthesisModel || process.env.LLM_MODEL || process.env.OLLAMA_MODEL || "qwen2.5:7b";
+  return createOpenAI({ baseURL, apiKey: "ollama" })(modelName);
+}
+
+// ─── System Prompts (design doc §5.2) ────────────────────────────────
+
+const CONTRADICTION_RULE = `
+Before synthesizing, examine all source facts for contradictions. If significant contradictions exist between source memories (e.g., conflicting facts, opposite recommendations, or incompatible claims), set insight_type to "contradiction" in your output regardless of the requested type.`;
+
+const SYSTEM_PROMPTS: Record<string, string> = {
+  cluster_summary: `You are a knowledge synthesis engine for a personal memory system.
+
+Given a cluster of related memories on the same topic, synthesize them into a single reference document. Identify the most important facts, patterns, and takeaways across all sources. Produce a concise synthesis paragraph (3-5 sentences), extract atomic distilled facts, and identify relationships between source memories.
+${CONTRADICTION_RULE}
+
+Respond with valid JSON matching the required schema.`,
+
+  evolution: `You are a knowledge synthesis engine for a personal memory system.
+
+Given a set of memories on the same topic saved at different times, identify how the user's understanding, position, or practices have changed over time. Highlight what shifted, what was added, and what was abandoned. Produce a synthesis paragraph (3-5 sentences) capturing the evolution narrative, extract atomic distilled facts, and identify temporal relationships between source memories.
+${CONTRADICTION_RULE}
+
+Respond with valid JSON matching the required schema.`,
+
+  connection: `You are a knowledge synthesis engine for a personal memory system.
+
+Given memories from different categories or types that are semantically related, identify and articulate the cross-domain connection. Explain why these seemingly different memories are related and what insight emerges from seeing them together. Produce a synthesis paragraph (3-5 sentences), extract atomic distilled facts, and map the cross-domain relationships between source memories.
+${CONTRADICTION_RULE}
+
+Respond with valid JSON matching the required schema.`,
+};
+
+// ─── Prompt Construction (design doc §5.3) ────────────────────────────
+
+/**
+ * Build the user message for LLM synthesis from cluster members.
+ */
+export function buildSynthesisPrompt(
+  cluster: ClusterMember[],
+  insightType: InsightType
+): string {
+  const sections = [`Insight type requested: ${insightType}`, ""];
+
+  for (let i = 0; i < cluster.length; i++) {
+    const m = cluster[i];
+    sections.push(`### Memory ${i + 1} (ID: ${m.id}, saved: ${m.date_saved})`);
+    sections.push(`- **Title:** ${m.title}`);
+    sections.push(`- **Type:** ${m.type}`);
+    sections.push(`- **Category:** ${m.category}`);
+    sections.push(`- **Tags:** ${m.tags.join(", ")}`);
+    sections.push("- **Facts:**");
+    for (const item of m.distilledItems) {
+      sections.push(`  - ${item}`);
+    }
+    const excerpt = m.rawSource.slice(0, 300);
+    sections.push(`- **Source excerpt:** "${excerpt}${m.rawSource.length > 300 ? "..." : ""}"`);
+    sections.push("");
+  }
+
+  return sections.join("\n");
+}
+
+// ─── Fallback Parse ──────────────────────────────────────────────────
+
+/**
+ * Parse InsightOutput from raw text response when structured output fails.
+ */
+export function fallbackParse(text: string): InsightOutput {
+  const stripped = text.replace(/^```(?:json)?\s*/m, "").replace(/```\s*$/m, "").trim();
+  const jsonMatch = stripped.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    throw new Error("Fallback parse failed: no JSON object found in response");
+  }
+
+  const raw = JSON.parse(jsonMatch[0]);
+
+  // Normalize tags: lowercase kebab-case
+  if (Array.isArray(raw.tags)) {
+    raw.tags = raw.tags
+      .map((t: unknown) =>
+        String(t)
+          .toLowerCase()
+          .replace(/[\s_]+/g, "-")
+          .replace(/[^a-z0-9-]/g, "")
+      )
+      .filter((t: string) => t.length > 0)
+      .slice(0, 5);
+  }
+
+  // Truncate distilled_items
+  if (Array.isArray(raw.distilled_items)) {
+    raw.distilled_items = raw.distilled_items.slice(0, 7);
+  }
+
+  return InsightOutputSchema.parse(raw);
+}
+
+// ─── Synthesis ────────────────────────────────────────────────────────
+
+/**
+ * Synthesize an insight from a cluster of memories using LLM.
+ * Uses Vercel AI SDK structured output with fallback to text + JSON parsing.
+ */
+export async function synthesizeInsight(
+  cluster: ClusterMember[],
+  insightType: InsightType,
+): Promise<SynthesisResult> {
+  const model = resolveModel();
+  const systemPrompt = SYSTEM_PROMPTS[insightType] || SYSTEM_PROMPTS.cluster_summary;
+  const userPrompt = buildSynthesisPrompt(cluster, insightType);
+
+  try {
+    const { output } = await generateText({
+      model,
+      output: Output.object({ schema: InsightOutputSchema }),
+      system: systemPrompt,
+      prompt: userPrompt,
+      temperature: 0,
+    });
+
+    if (!output) {
+      throw new Error("No structured output generated by model");
+    }
+
+    return { ...output, _extractionPath: "structured" as const };
+  } catch (primaryError) {
+    try {
+      const { text } = await generateText({
+        model,
+        system: systemPrompt,
+        prompt: userPrompt + "\n\nRespond with ONLY valid JSON matching the schema.",
+        temperature: 0,
+      });
+
+      const parsed = fallbackParse(text);
+      return { ...parsed, _extractionPath: "fallback" as const };
+    } catch (fallbackError) {
+      console.warn("Synthesis fallback parse also failed:", fallbackError);
+      throw primaryError;
+    }
+  }
+}
+
+// ─── Confidence Scoring (design doc §10.5.2) ─────────────────────────
+
+/**
+ * Compute insight confidence using the revised formula from design doc §10.5.2.
+ *
+ * This supersedes the simpler §6 formula (avgSimilarity * 0.7 + sizeFactor * 0.3).
+ */
+export function computeInsightConfidence(params: {
+  avgSimilarity: number;
+  clusterSize: number;
+  reinforcementCount: number;
+  sourceIntegrity: number; // ratio of source_ids still on disk (0.0–1.0)
+}): number {
+  const { avgSimilarity, clusterSize, reinforcementCount, sourceIntegrity } = params;
+
+  const sizeFactor = Math.min((clusterSize - 2) / 3, 1.0);
+  const reinforcementFactor = Math.min(1.0 + reinforcementCount * 0.05, 1.15);
+  const base = avgSimilarity * 0.5 + sizeFactor * 0.5;
+  const adjusted = base * reinforcementFactor * sourceIntegrity;
+  return Number(Math.min(adjusted, 1.0).toFixed(2));
+}


### PR DESCRIPTION
## Summary
- Implements candidate finder with QMD search, seed exclusion, and insight-type filtering
- Adds cluster validation (3-8 members) with top-score truncation and deterministic classification (connection/evolution/cluster_summary)
- Adds LLM synthesis engine with type-specific prompts, Vercel AI SDK structured output, and fallback parsing
- Implements revised confidence scoring formula (§10.5.2) with reinforcement and source integrity factors
- 44 unit tests covering all acceptance criteria

## Test plan
- [x] `bun tsc --noEmit` passes
- [x] `bun test` — 44 tests pass across candidate finder and synthesizer
- [ ] Manual verification with real QMD index in dev environment

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)