### PR TITLE
feat: Add embedded MCP server in core-api (MCP-002)

### DIFF
--- a/apps/core-api/package.json
+++ b/apps/core-api/package.json
@@ -9,12 +9,13 @@
     "build:bin": "bun build --compile src/index.ts --outfile bin/kore-server"
   },
   "dependencies": {
+    "@elysiajs/bearer": "^1.2.8",
+    "@elysiajs/cors": "^1.2.0",
     "@kore/llm-extractor": "workspace:*",
     "@kore/qmd-client": "workspace:*",
     "@kore/shared-types": "workspace:*",
+    "@modelcontextprotocol/sdk": "^1.27.1",
     "elysia": "^1.2.25",
-    "@elysiajs/bearer": "^1.2.8",
-    "@elysiajs/cors": "^1.2.0",
     "zod": "^3.24.2"
   }
 }

--- a/apps/core-api/src/index.ts
+++ b/apps/core-api/src/index.ts
@@ -18,6 +18,7 @@ import {
   reconcileOnStartup,
 } from "./consolidation-loop";
 import type { ConsolidationHandle } from "./consolidation-loop";
+import { startMcpServer } from "./mcp";
 import * as qmdClient from "@kore/qmd-client";
 import type { KorePlugin, PluginStartDeps } from "@kore/shared-types";
 
@@ -178,6 +179,34 @@ for (const plugin of plugins) {
       console.error(`Plugin "${plugin.name}" routes failed (non-fatal):`, err);
     }
   }
+}
+
+// ── Start MCP server (after consolidation loop, before listen) ───────
+const mcpHandle = await startMcpServer({
+  dataPath,
+  memoryIndex,
+  queue,
+  qmdSearch: qmdClient.search,
+  qmdStatus,
+  consolidationTracker,
+  eventDispatcher,
+  consolidationLoopHandle: consolidation,
+});
+
+if (mcpHandle) {
+  const apiKey = process.env.KORE_API_KEY;
+  app.all(mcpHandle.mcpPath, async ({ request, set }) => {
+    // Authenticate MCP requests with the same KORE_API_KEY as the REST API
+    if (apiKey) {
+      const authHeader = request.headers.get("authorization");
+      const token = authHeader?.startsWith("Bearer ") ? authHeader.slice(7) : null;
+      if (token !== apiKey) {
+        set.status = 401;
+        return { error: "Missing or invalid Bearer token", code: "UNAUTHORIZED" };
+      }
+    }
+    return mcpHandle.handleRequest(request);
+  });
 }
 
 app.listen({ port: 3000, reusePort: false });

--- a/apps/core-api/src/mcp.test.ts
+++ b/apps/core-api/src/mcp.test.ts
@@ -1,0 +1,423 @@
+import { describe, test, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { join } from "node:path";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { MemoryIndex } from "./memory-index";
+import { QueueRepository } from "./queue";
+import { createMcpServer } from "./mcp";
+import type { OperationDeps } from "./operations";
+import type { QmdHealthSummary } from "./app";
+import type { HybridQueryResult, SearchOptions } from "@kore/qmd-client";
+
+// ─── Test Fixtures ────────────────────────────────────────────────
+
+let tempDir: string;
+let queue: QueueRepository;
+let memoryIndex: MemoryIndex;
+
+const sampleMemoryContent = `---
+id: mem-001
+type: place
+category: qmd://travel/food/ramen
+date_saved: 2026-03-15T10:00:00Z
+source: apple_notes
+tags: ["ramen", "tokyo"]
+intent: recommendation
+confidence: 0.9
+---
+
+# Best Ramen in Ikebukuro
+
+## Distilled Memory Items
+- Mutekiya in Ikebukuro is known for rich 48-hour pork bone broth
+- Best for solo dining at the counter
+- Open late until midnight
+
+## Original Source
+John recommended Mutekiya for the best tonkotsu ramen experience.
+`;
+
+const sampleMemoryContent2 = `---
+id: mem-002
+type: note
+category: qmd://tech/react
+date_saved: 2026-03-10T08:00:00Z
+source: web_clipper
+tags: ["react", "hooks"]
+intent: reference
+confidence: 0.85
+---
+
+# React Hook Patterns
+
+## Distilled Memory Items
+- useReducer is preferred over useState for complex state logic
+- Custom hooks should start with "use" prefix
+
+## Original Source
+Article on React best practices.
+`;
+
+const sampleInsightContent = `---
+id: ins-001
+type: insight
+insight_type: cluster_summary
+status: active
+category: qmd://travel/food
+date_saved: 2026-03-16T12:00:00Z
+source: consolidation
+tags: ["ramen", "food"]
+confidence: 0.88
+source_ids: ["mem-001"]
+reinforcement_count: 2
+last_synthesized_at: 2026-03-16T12:00:00Z
+---
+
+# Ramen Knowledge
+
+## Synthesis
+The user has extensive knowledge about ramen restaurants in Tokyo.
+
+## Distilled Memory Items
+- Mutekiya is the top recommended spot in Ikebukuro
+- Solo dining at counter is preferred
+`;
+
+function mockQmdResult(overrides: Partial<HybridQueryResult> & { file: string; score: number }): HybridQueryResult {
+  return {
+    displayPath: "",
+    title: "",
+    body: "",
+    bestChunk: "",
+    bestChunkPos: 0,
+    context: null,
+    docid: "",
+    ...overrides,
+  };
+}
+
+function createMockDeps(overrides?: Partial<OperationDeps>): OperationDeps {
+  return {
+    dataPath: tempDir,
+    memoryIndex,
+    queue,
+    qmdSearch: async () => [],
+    qmdStatus: async () => ({ status: "ok" as const, doc_count: 10, collections: 1, needs_embedding: 0 }),
+    ...overrides,
+  };
+}
+
+// ─── Helper: call a tool via the McpServer ─────────────────────────
+
+function getTools(server: ReturnType<typeof createMcpServer>): Record<string, any> {
+  return (server as any)._registeredTools;
+}
+
+async function callTool(
+  server: ReturnType<typeof createMcpServer>,
+  toolName: string,
+  args: Record<string, unknown> = {}
+): Promise<{ isError?: boolean; text: string }> {
+  const tools = getTools(server);
+  const tool = tools[toolName];
+  if (!tool) throw new Error(`Tool "${toolName}" not registered`);
+
+  const result = await tool.handler(args, {});
+  const text = result.content?.[0]?.text ?? "";
+  return { isError: result.isError ?? false, text };
+}
+
+// ─── Setup / Teardown ─────────────────────────────────────────────
+
+beforeAll(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), "kore-mcp-test-"));
+  const dbPath = join(tempDir, "queue.db");
+  queue = new QueueRepository(dbPath);
+
+  // Create data directories
+  await mkdir(join(tempDir, "places"), { recursive: true });
+  await mkdir(join(tempDir, "notes"), { recursive: true });
+  await mkdir(join(tempDir, "insights"), { recursive: true });
+
+  // Write sample memory files
+  await writeFile(join(tempDir, "places", "best-ramen.md"), sampleMemoryContent);
+  await writeFile(join(tempDir, "notes", "react-hooks.md"), sampleMemoryContent2);
+  await writeFile(join(tempDir, "insights", "ramen-knowledge.md"), sampleInsightContent);
+
+  // Build memory index
+  memoryIndex = new MemoryIndex();
+  await memoryIndex.build(tempDir);
+});
+
+afterAll(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+// ─── Tests ────────────────────────────────────────────────────────
+
+describe("MCP Server", () => {
+  describe("createMcpServer", () => {
+    test("registers all 6 tools", () => {
+      const server = createMcpServer(createMockDeps());
+      const tools = getTools(server);
+      const names = Object.keys(tools);
+      expect(names).toContain("recall");
+      expect(names).toContain("remember");
+      expect(names).toContain("inspect");
+      expect(names).toContain("insights");
+      expect(names).toContain("health");
+      expect(names).toContain("consolidate");
+      expect(names.length).toBe(6);
+    });
+
+    test("tool descriptions contain WHEN TO USE sections", () => {
+      const server = createMcpServer(createMockDeps());
+      const tools = getTools(server);
+      for (const [name, tool] of Object.entries(tools)) {
+        expect(tool.description).toContain("WHEN TO USE");
+      }
+    });
+
+    test("server has instructions set", () => {
+      const server = createMcpServer(createMockDeps());
+      const lowLevelServer = (server as any).server;
+      expect(lowLevelServer._instructions).toBeTruthy();
+      expect(lowLevelServer._instructions).toContain("PROACTIVE RECALL");
+      expect(lowLevelServer._instructions).toContain("PREFER INSIGHTS");
+      expect(lowLevelServer._instructions).toContain("OFFER TO REMEMBER");
+      expect(lowLevelServer._instructions).toContain("NEVER FABRICATE");
+      expect(lowLevelServer._instructions).toContain("RESPECT CONFIDENCE");
+    });
+  });
+
+  describe("recall tool", () => {
+    test("returns results from no-query path", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "recall", { type: "place" });
+      expect(result.isError).toBe(false);
+
+      const data = JSON.parse(result.text);
+      expect(data.results).toBeArray();
+      expect(data.results.length).toBeGreaterThan(0);
+      expect(data.results[0].type).toBe("place");
+      expect(data.offset).toBe(0);
+      expect(typeof data.has_more).toBe("boolean");
+    });
+
+    test("returns results from query path", async () => {
+      const deps = createMockDeps({
+        qmdSearch: async (query: string) => [
+          mockQmdResult({
+            file: join(tempDir, "places", "best-ramen.md"),
+            score: 0.95,
+            title: "Best Ramen",
+          }),
+        ],
+      });
+      const server = createMcpServer(deps);
+      const result = await callTool(server, "recall", { query: "ramen" });
+      expect(result.isError).toBe(false);
+
+      const data = JSON.parse(result.text);
+      expect(data.results.length).toBe(1);
+      expect(data.results[0].id).toBe("mem-001");
+      expect(data.query).toBe("ramen");
+    });
+
+    test("returns structured error for search failures", async () => {
+      const deps = createMockDeps({
+        qmdSearch: async () => { throw new Error("Index not available"); },
+      });
+      const server = createMcpServer(deps);
+      const result = await callTool(server, "recall", { query: "test" });
+      expect(result.isError).toBe(true);
+      expect(result.text).toContain("Search index is not available");
+    });
+  });
+
+  describe("remember tool", () => {
+    test("enqueues content and returns task_id", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "remember", {
+        content: "Great sushi spot in Shibuya called Sushi Dai",
+        source: "agent",
+        suggested_tags: ["sushi", "tokyo"],
+      });
+      expect(result.isError).toBe(false);
+
+      const data = JSON.parse(result.text);
+      expect(data.status).toBe("queued");
+      expect(data.task_id).toBeTruthy();
+      expect(data.message).toContain("Memory queued");
+    });
+
+    test("returns error when queue is unavailable", async () => {
+      const brokenQueue = {
+        enqueue: () => { throw new Error("Queue unavailable"); },
+      } as any;
+      const deps = createMockDeps({ queue: brokenQueue });
+      const server = createMcpServer(deps);
+      const result = await callTool(server, "remember", { content: "test" });
+      expect(result.isError).toBe(true);
+      expect(result.text).toContain("ingestion queue is not available");
+    });
+  });
+
+  describe("inspect tool", () => {
+    test("returns full memory details for valid ID", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "inspect", { id: "mem-001" });
+      expect(result.isError).toBe(false);
+
+      const data = JSON.parse(result.text);
+      expect(data.id).toBe("mem-001");
+      expect(data.title).toBe("Best Ramen in Ikebukuro");
+      expect(data.type).toBe("place");
+      expect(data.category).toBe("qmd://travel/food/ramen");
+      expect(data.distilled_items).toBeArray();
+      expect(data.distilled_items.length).toBe(3);
+      expect(data.content).toContain("---");
+    });
+
+    test("returns error for unknown ID", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "inspect", { id: "nonexistent-id" });
+      expect(result.isError).toBe(true);
+      expect(result.text).toContain("was not found");
+    });
+  });
+
+  describe("insights tool", () => {
+    test("returns active insights when no query", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "insights", {});
+      expect(result.isError).toBe(false);
+
+      const data = JSON.parse(result.text);
+      expect(data.results).toBeArray();
+      expect(data.results.length).toBeGreaterThan(0);
+      expect(data.results[0].insight_type).toBe("cluster_summary");
+      expect(data.results[0].status).toBe("active");
+    });
+
+    test("filters by insight_type", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "insights", { insight_type: "evolution" });
+      expect(result.isError).toBe(false);
+
+      const data = JSON.parse(result.text);
+      expect(data.results.length).toBe(0); // no evolution insights in fixtures
+    });
+
+    test("returns structured error for search failures", async () => {
+      const deps = createMockDeps({
+        qmdSearch: async () => { throw new Error("unavailable"); },
+      });
+      const server = createMcpServer(deps);
+      const result = await callTool(server, "insights", { query: "test" });
+      expect(result.isError).toBe(true);
+      expect(result.text).toContain("Search index is not available");
+    });
+  });
+
+  describe("health tool", () => {
+    test("returns system health", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "health");
+      expect(result.isError).toBe(false);
+
+      const data = JSON.parse(result.text);
+      expect(data.version).toBeTruthy();
+      expect(data.memories).toBeDefined();
+      expect(data.memories.total).toBeGreaterThan(0);
+      expect(data.memories.by_type).toBeDefined();
+      expect(data.queue).toBeDefined();
+      expect(typeof data.queue.pending).toBe("number");
+      expect(typeof data.queue.processing).toBe("number");
+      expect(typeof data.queue.failed).toBe("number");
+      expect(data.index).toBeDefined();
+      expect(typeof data.index.documents).toBe("number");
+      expect(typeof data.index.status).toBe("string");
+    });
+
+    test("returns error on health check failure", async () => {
+      const deps = createMockDeps({
+        qmdStatus: async () => { throw new Error("QMD down"); },
+      });
+      const server = createMcpServer(deps);
+      const result = await callTool(server, "health");
+      expect(result.isError).toBe(true);
+    });
+  });
+
+  describe("consolidate tool", () => {
+    test("returns error when consolidation tracker not available", async () => {
+      const deps = createMockDeps({
+        consolidationTracker: undefined,
+      });
+      const server = createMcpServer(deps);
+      const result = await callTool(server, "consolidate", { dry_run: false });
+      expect(result.isError).toBe(true);
+      expect(result.text).toContain("consolidation system is not available");
+    });
+  });
+
+  describe("error handling", () => {
+    test("all tools return structured MCP error format", async () => {
+      // Use a server with broken deps to trigger errors
+      const brokenDeps = createMockDeps({
+        qmdSearch: async () => { throw new Error("broken"); },
+        qmdStatus: async () => { throw new Error("broken"); },
+      });
+      const server = createMcpServer(brokenDeps);
+
+      // recall with query should fail on broken search
+      const recallResult = await callTool(server, "recall", { query: "test" });
+      expect(recallResult.isError).toBe(true);
+      expect(recallResult.text).toContain("Error:");
+
+      // health should fail on broken qmdStatus
+      const healthResult = await callTool(server, "health");
+      expect(healthResult.isError).toBe(true);
+      expect(healthResult.text).toContain("Error:");
+
+      // inspect with nonexistent ID should return structured error
+      const inspectResult = await callTool(server, "inspect", { id: "xxx" });
+      expect(inspectResult.isError).toBe(true);
+      expect(inspectResult.text).toContain("Error:");
+    });
+
+    test("no unhandled exceptions reach the agent", async () => {
+      const deps = createMockDeps({
+        qmdSearch: async () => { throw new TypeError("Cannot read properties of undefined"); },
+      });
+      const server = createMcpServer(deps);
+
+      // Should NOT throw — should return structured error
+      const result = await callTool(server, "recall", { query: "test" });
+      expect(result.isError).toBe(true);
+      // The error text should be present (not an unhandled rejection)
+      expect(result.text).toBeTruthy();
+    });
+  });
+
+  describe("result passthrough to MCP format", () => {
+    test("successful results are JSON-serialized in content[0].text", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "recall", { type: "place" });
+
+      // The result should be valid JSON
+      const parsed = JSON.parse(result.text);
+      expect(parsed).toBeDefined();
+      expect(parsed.results).toBeArray();
+    });
+
+    test("error results have isError: true and human-readable text", async () => {
+      const server = createMcpServer(createMockDeps());
+      const result = await callTool(server, "inspect", { id: "missing" });
+
+      expect(result.isError).toBe(true);
+      expect(result.text).toMatch(/^Error: /);
+    });
+  });
+});

--- a/apps/core-api/src/mcp.ts
+++ b/apps/core-api/src/mcp.ts
@@ -1,0 +1,405 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { WebStandardStreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js";
+import { z } from "zod";
+import {
+  recall,
+  remember,
+  inspect,
+  insights,
+  health,
+  consolidate,
+} from "./operations";
+import type { OperationDeps } from "./operations";
+
+// ─── Tool Descriptions (§5 of design doc) ──────────────────────────
+
+const RECALL_DESCRIPTION = `Search the user's personal knowledge base — saved bookmarks, notes, recommendations,
+experiences, and synthesized insights. Returns structured results with metadata
+(type, intent, confidence, tags) so you can reason about the nature of each memory.
+
+WHEN TO USE:
+- Before answering questions that could benefit from the user's personal context.
+  Topics include: restaurants, travel, recipes, books, movies, people, places,
+  projects, technical preferences, health, hobbies, learning resources, or any
+  subject where the user might have saved relevant information in the past.
+- The user often forgets what they've saved. Proactively checking is more helpful
+  than waiting to be asked. If the conversation topic MIGHT have personal context,
+  check.
+- Use the intent filter to narrow results: "recommendation" for suggestions others
+  gave the user, "aspiration" for things the user wants to try, "how-to" for
+  instructions and procedures.
+- Use created_after/created_before for time-based queries: "restaurants saved
+  last month", "articles from 2024", "recent bookmarks".
+- Use offset for pagination when you need more results than a single page.
+- query is optional. For purely metadata-based browsing (e.g., "show me all
+  my aspirations" or "list recent places"), omit query entirely and use the
+  type/intent/created_after filters — results are sorted by date_saved
+  descending. Only pass a semantic query when content relevance matters.
+
+WHEN NOT TO USE:
+- General knowledge questions with no personal angle ("what is photosynthesis")
+- Pure code generation or debugging tasks with no personal context
+- When the user has explicitly said they don't want memory lookup
+
+IF RESULTS ARE EMPTY OR SPARSE:
+- Try broadening your search terms or removing specific filters before
+  concluding nothing exists. A query for "tonkotsu ramen tokyo" that returns
+  nothing might still return results for "ramen tokyo" or "ramen".
+- Try omitting intent/tag filters to widen the match set, then narrow manually.
+
+RESULT INTERPRETATION:
+- score: How relevant this result is to your query (from the search engine)
+- confidence: How reliably the memory was extracted from the original source
+- type "insight": A synthesized document combining multiple memories — prefer
+  these when the user wants a summary rather than individual saved items`;
+
+const REMEMBER_DESCRIPTION = `Save noteworthy information to the user's personal knowledge base. The content
+will be processed by an LLM to extract key facts, categorize it, and make it
+searchable for future recall.
+
+WHEN TO USE:
+- When the conversation produces information the user would want to recall later:
+  a restaurant recommendation discovered, a useful technique explained, a decision
+  made, a resource found, a preference expressed.
+- When the user explicitly says "remember this", "save this", "note this down".
+
+IMPORTANT:
+- Ask the user for confirmation before saving, unless they've told you to save
+  freely. Example: "This looks like a useful resource — would you like me to save
+  it to your memory?"
+- Include enough context in the content for the extraction to produce good results.
+  Don't just save "Mutekiya" — save "Mutekiya Ramen in Ikebukuro, Tokyo —
+  recommended by John for solo dining, known for rich 48-hour pork bone broth."
+- The saved content goes through LLM extraction, so raw/messy text is fine.
+- Use suggested_tags and suggested_category when you have strong context about
+  the content's domain. These are hints — the extraction pipeline may refine them,
+  but your suggestions improve extraction accuracy.`;
+
+const INSPECT_DESCRIPTION = `Get the complete details of a specific memory by its ID. Returns all metadata,
+distilled facts, raw source content, and consolidation state.
+
+WHEN TO USE:
+- After recall returns results and you need deeper detail on a specific item
+  (e.g., the full raw source text, or which insights reference this memory).
+- When you need to verify the quality of a memory (check its confidence score,
+  see the original source text vs. the extracted facts).
+- When exploring the consolidation graph (follow insight_refs or source_ids).`;
+
+const INSIGHTS_DESCRIPTION = `Query the synthesized knowledge layer — higher-order documents that connect and
+consolidate multiple individual memories on the same topic. Insights capture
+the user's evolved understanding, cross-domain connections, and consolidated
+reference material.
+
+WHEN TO USE:
+- When the user asks about their "current view", "overall understanding", or
+  "what do I know about" a topic — insights provide the synthesized answer.
+- When recall returns many fragmented results on the same topic (5+ results
+  about sourdough baking) — check insights for a consolidated version first.
+- When the user asks about how their thinking has changed over time — use
+  insight_type "evolution".
+- When you want to understand connections across different areas of the user's
+  knowledge — use insight_type "connection".
+
+RESULT INTERPRETATION:
+- synthesis: A 3-5 sentence summary combining knowledge from multiple memories
+- source_ids: The individual memories this insight was built from
+- reinforcement_count: How many times new evidence has updated this insight
+  (higher = more actively confirmed knowledge)
+- status "evolving": This insight is being updated with new evidence`;
+
+const HEALTH_DESCRIPTION = `Check Kore system health — memory counts by type, ingestion queue status,
+search index state, and sync status.
+
+WHEN TO USE:
+- When the user asks about their memory system ("how many memories do I have?",
+  "is Kore running?")
+- When diagnosing unexpected search results (check if the index is still
+  embedding, or if the queue has failed tasks)`;
+
+const CONSOLIDATE_DESCRIPTION = `Trigger knowledge synthesis — clusters related memories and produces insight
+documents that capture higher-order understanding.
+
+WHEN TO USE:
+- When recall returns many fragmented results on a topic and no insight exists
+  yet. Offer: "You have 8 separate notes about sourdough. Would you like me to
+  synthesize them into a consolidated reference?"
+- When the user explicitly asks to consolidate or synthesize their knowledge.
+- Use dry_run=true first to preview what would be synthesized before committing.
+
+NOTE: Consolidation runs automatically in the background every 30 minutes.
+This tool is for on-demand synthesis when the user wants it now. The call
+blocks until the cycle completes (typically <5s) and returns the result.
+
+RESULT INTERPRETATION:
+- "consolidated": synthesis succeeded — insightId contains the new insight's ID
+- "no_seed": nothing ready to consolidate yet; more memories needed
+- "cluster_too_small": a candidate seed exists but lacks related memories yet
+- "retired_reeval" / "synthesis_failed": transient failure; suggest trying again
+- dry_run "no_seed": no candidates at all — the knowledge base may be too sparse`;
+
+// ─── Server Instructions (§6 of design doc) ────────────────────────
+
+const SERVER_INSTRUCTIONS = `You have access to the user's personal knowledge base through Kore. This system
+contains bookmarks, notes, recommendations, experiences, and synthesized insights
+the user has saved over time — often months or years ago.
+
+The user frequently forgets what they've saved. Your role is to bridge the gap
+between saved knowledge and active recall.
+
+Interaction patterns:
+
+1. PROACTIVE RECALL: When the user discusses a topic that could involve personal
+   context (travel, food, projects, preferences, people, places), call \`recall\`
+   BEFORE composing your response. Weave relevant memories into your answer
+   naturally — don't list them mechanically.
+
+2. PREFER INSIGHTS: When recall returns many results on the same topic, check
+   \`insights\` for a synthesized view. Present the insight's synthesis rather
+   than listing individual memories, unless the user wants specifics.
+
+3. OFFER TO REMEMBER: When the conversation produces valuable information the
+   user might want later, offer to save it. Don't save silently.
+
+4. NEVER FABRICATE: If recall returns nothing relevant, say so. Don't guess
+   what the user might have saved. "I don't see anything in your saved memories
+   about that" is a perfectly good response.
+
+5. RESPECT CONFIDENCE: When a memory has low confidence (< 0.5), mention that
+   the extraction may be imperfect: "I found a note about this, though the
+   details might not be fully accurate."`;
+
+// ─── Error Helpers ──────────────────────────────────────────────────
+
+function mcpError(message: string) {
+  return {
+    isError: true as const,
+    content: [{ type: "text" as const, text: `Error: ${message}` }],
+  };
+}
+
+function mcpSuccess(data: unknown) {
+  return {
+    content: [{ type: "text" as const, text: JSON.stringify(data) }],
+  };
+}
+
+// ─── MCP Server Creation ────────────────────────────────────────────
+
+export function createMcpServer(deps: OperationDeps) {
+  const server = new McpServer(
+    { name: "kore", version: "1.0.0" },
+    {
+      capabilities: { tools: {} },
+      instructions: SERVER_INSTRUCTIONS,
+    }
+  );
+
+  // ── recall ────────────────────────────────────────────────────────
+  server.tool(
+    "recall",
+    RECALL_DESCRIPTION,
+    {
+      query: z.string().optional().describe("Natural language search query (optional — if omitted, returns recent memories sorted by date_saved descending)"),
+      type: z.string().optional().describe('Filter by memory type: "place" | "media" | "note" | "person"'),
+      intent: z.string().optional().describe('Filter by intent: "recommendation" | "reference" | "personal-experience" | "aspiration" | "how-to"'),
+      tags: z.array(z.string()).optional().describe("Filter to memories containing ALL specified tags"),
+      created_after: z.string().optional().describe("ISO 8601 date — only return memories saved after this date"),
+      created_before: z.string().optional().describe("ISO 8601 date — only return memories saved before this date"),
+      limit: z.number().optional().describe("Max results (default: 10, max: 50)"),
+      offset: z.number().optional().describe("Skip first N results for pagination (default: 0)"),
+      min_score: z.number().optional().describe("Minimum QMD relevance score (default: 0.0)"),
+      min_confidence: z.number().optional().describe("Minimum extraction confidence (default: 0.0)"),
+      include_insights: z.boolean().optional().describe("Include insight-type results (default: true)"),
+    },
+    async (args) => {
+      try {
+        const result = await recall(args, deps);
+        return mcpSuccess(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes("not available") || message.includes("unavailable")) {
+          return mcpError("Search index is not available. The system may still be starting up.");
+        }
+        return mcpError(message);
+      }
+    }
+  );
+
+  // ── remember ──────────────────────────────────────────────────────
+  server.tool(
+    "remember",
+    REMEMBER_DESCRIPTION,
+    {
+      content: z.string().describe("The raw content to remember (required)"),
+      source: z.string().optional().describe('Where this came from (default: "agent")'),
+      url: z.string().optional().describe("Source URL if applicable"),
+      priority: z.string().optional().describe('"low" | "normal" | "high" (default: "normal")'),
+      suggested_tags: z.array(z.string()).optional().describe("Agent-suggested tags — passed as hints to the extraction pipeline"),
+      suggested_category: z.string().optional().describe('Agent-suggested category (e.g., "travel/food/ramen") — hint, not override'),
+    },
+    async (args) => {
+      try {
+        const result = await remember(
+          { ...args, priority: (args.priority as "low" | "normal" | "high") ?? "normal" },
+          deps
+        );
+        return mcpSuccess(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return mcpError("The ingestion queue is not available.");
+      }
+    }
+  );
+
+  // ── inspect ───────────────────────────────────────────────────────
+  server.tool(
+    "inspect",
+    INSPECT_DESCRIPTION,
+    {
+      id: z.string().describe("Memory UUID (required)"),
+    },
+    async (args) => {
+      try {
+        const result = await inspect(args.id, deps);
+        if (!result) {
+          return mcpError(`Memory with ID ${args.id} was not found.`);
+        }
+        return mcpSuccess(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return mcpError(message);
+      }
+    }
+  );
+
+  // ── insights ──────────────────────────────────────────────────────
+  server.tool(
+    "insights",
+    INSIGHTS_DESCRIPTION,
+    {
+      query: z.string().optional().describe("Semantic search query (optional — if omitted, lists recent insights)"),
+      insight_type: z.string().optional().describe('Filter: "cluster_summary" | "evolution" | "contradiction" | "connection"'),
+      status: z.string().optional().describe('Filter: "active" | "evolving" | "degraded" (default: "active")'),
+      limit: z.number().optional().describe("Max results (default: 5, max: 20)"),
+    },
+    async (args) => {
+      try {
+        const result = await insights(args, deps);
+        return mcpSuccess(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes("not available") || message.includes("unavailable")) {
+          return mcpError("Search index is not available. The system may still be starting up.");
+        }
+        return mcpError(message);
+      }
+    }
+  );
+
+  // ── health ────────────────────────────────────────────────────────
+  server.tool(
+    "health",
+    HEALTH_DESCRIPTION,
+    {},
+    async () => {
+      try {
+        const result = await health(deps);
+        return mcpSuccess(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        return mcpError(message);
+      }
+    }
+  );
+
+  // ── consolidate ───────────────────────────────────────────────────
+  server.tool(
+    "consolidate",
+    CONSOLIDATE_DESCRIPTION,
+    {
+      dry_run: z.boolean().optional().describe("Preview only, don't write insight files (default: false)"),
+    },
+    async (args) => {
+      try {
+        const result = await consolidate(args, deps);
+        return mcpSuccess(result);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.includes("not available")) {
+          return mcpError("The consolidation system is not available.");
+        }
+        return mcpError(message);
+      }
+    }
+  );
+
+  return server;
+}
+
+// ─── Session Management + Request Handler ────────────────────────────
+
+interface McpSession {
+  transport: WebStandardStreamableHTTPServerTransport;
+  server: McpServer;
+}
+
+/**
+ * Creates an MCP request handler that manages sessions and routes requests
+ * to the appropriate transport. Each session gets its own McpServer + transport pair.
+ */
+export function createMcpRequestHandler(deps: OperationDeps) {
+  const sessions = new Map<string, McpSession>();
+
+  return async function handleMcpRequest(request: Request): Promise<Response> {
+    const sessionId = request.headers.get("mcp-session-id");
+
+    // Route to existing session
+    if (sessionId) {
+      const session = sessions.get(sessionId);
+      if (session) {
+        return session.transport.handleRequest(request);
+      }
+      // Invalid/expired session — let a fresh transport handle it (it will reject properly)
+    }
+
+    // New session: create transport + server pair
+    const transport = new WebStandardStreamableHTTPServerTransport({
+      sessionIdGenerator: () => crypto.randomUUID(),
+      onsessioninitialized: (id) => {
+        sessions.set(id, { transport, server: mcpServer });
+      },
+      onsessionclosed: (id) => {
+        sessions.delete(id);
+      },
+    });
+
+    const mcpServer = createMcpServer(deps);
+    await mcpServer.connect(transport);
+
+    return transport.handleRequest(request);
+  };
+}
+
+// ─── Startup ─────────────────────────────────────────────────────────
+
+export async function startMcpServer(deps: OperationDeps) {
+  const enabled = process.env.KORE_MCP_ENABLED !== "false";
+  if (!enabled) {
+    console.log("MCP server disabled (KORE_MCP_ENABLED=false)");
+    return null;
+  }
+
+  const mcpPath = process.env.KORE_MCP_PATH ?? "/mcp";
+  if (!mcpPath) {
+    console.log("MCP HTTP transport disabled (KORE_MCP_PATH is empty)");
+    return null;
+  }
+
+  const handleRequest = createMcpRequestHandler(deps);
+
+  console.log(`MCP server started (path: ${mcpPath})`);
+
+  return { handleRequest, mcpPath };
+}
+
+export type McpServerHandle = Awaited<ReturnType<typeof startMcpServer>>;

--- a/bun.lock
+++ b/bun.lock
@@ -42,6 +42,7 @@
         "@kore/llm-extractor": "workspace:*",
         "@kore/qmd-client": "workspace:*",
         "@kore/shared-types": "workspace:*",
+        "@modelcontextprotocol/sdk": "^1.27.1",
         "elysia": "^1.2.25",
         "zod": "^3.24.2",
       },


### PR DESCRIPTION
Closes #84

### Summary
Implements the embedded MCP server in core-api with all 6 tools (recall, remember, inspect, insights, health, consolidate) using the @modelcontextprotocol/sdk. Each tool delegates to shared operations from MCP-001, includes verbatim tool descriptions and server instructions from the design doc, mounts at /mcp with bearer token auth, and is gated by KORE_MCP_ENABLED. Includes 20 unit tests covering tool registration, schema validation, structured error responses, and result passthrough.
