### PR TITLE
feat: Align CLI commands with shared operations module (MCP-003)

### DIFF
--- a/apps/cli/src/commands/consolidate.ts
+++ b/apps/cli/src/commands/consolidate.ts
@@ -1,45 +1,16 @@
 import pc from "picocolors";
+import { createSpinner } from "nanospinner";
 import { apiFetch } from "../api.ts";
-import { API_URL } from "../utils/env.ts";
 
-interface CandidateDebugInfo {
-  query: string;
-  rawResultCount: number;
-  filteredOutSelf: number;
-  filteredOutInsights: number;
-  afterFilterCount: number;
-  topScores: number[];
-}
-
-interface ConsolidateResponse {
-  status: string;
-  insightId?: string;
+interface ConsolidateOutput {
+  status: "consolidated" | "no_seed" | "cluster_too_small" | "retired_reeval" | "synthesis_failed" | "dry_run";
   seed?: { id: string; title: string };
-  clusterSize?: number;
-  candidateCount?: number;
+  insight_id?: string;
+  cluster_size?: number;
+  candidate_count?: number;
   candidates?: Array<{ id: string; title: string; score: number }>;
-  proposedInsightType?: string;
-  estimatedConfidence?: number;
-  debug?: CandidateDebugInfo;
-}
-
-function formatDebug(debug: CandidateDebugInfo): string {
-  const lines = [
-    pc.dim("─── Diagnostics ─────────────────────────"),
-    `Query:   "${debug.query.slice(0, 100)}${debug.query.length > 100 ? "..." : ""}"`,
-    `QMD returned:  ${debug.rawResultCount} result(s)`,
-  ];
-  if (debug.topScores.length > 0) {
-    lines.push(`Top scores:    ${debug.topScores.map((s) => s.toFixed(3)).join(", ")}`);
-  }
-  if (debug.filteredOutSelf > 0 || debug.filteredOutInsights > 0) {
-    lines.push(
-      `Filtered out:  ${debug.filteredOutSelf} self, ${debug.filteredOutInsights} insight(s)`,
-    );
-  }
-  lines.push(`After filter:  ${debug.afterFilterCount} candidate(s)`);
-  lines.push(pc.dim("──────────────────────────────────────────"));
-  return lines.join("\n");
+  proposed_insight_type?: string;
+  estimated_confidence?: number;
 }
 
 export async function consolidateCommand(opts: {
@@ -48,93 +19,95 @@ export async function consolidateCommand(opts: {
   json: boolean;
   verbose: boolean;
 }): Promise<void> {
-  const params = new URLSearchParams();
-  if (opts.dryRun) params.set("dry_run", "true");
-  if (opts.resetFailed) params.set("reset_failed", "true");
+  // If reset-failed, call the old endpoint first
+  if (opts.resetFailed) {
+    const resetResult = await apiFetch<unknown>("/api/v1/consolidate?reset_failed=true", {
+      method: "POST",
+    });
+    if (!resetResult.ok) {
+      if (opts.json) {
+        process.stderr.write(JSON.stringify({ error: resetResult.message }) + "\n");
+      } else {
+        process.stderr.write(`Error: Failed to reset failed entries: ${resetResult.message}\n`);
+      }
+      process.exit(1);
+    }
+  }
 
-  const qs = params.toString();
-  const path = `/api/v1/consolidate${qs ? `?${qs}` : ""}`;
+  const isTTY = process.stdout.isTTY && !opts.json && !opts.dryRun;
+  const spinner = isTTY ? createSpinner("Consolidating…").start() : null;
 
-  const result = await apiFetch<ConsolidateResponse>(path, { method: "POST" });
+  const body: Record<string, unknown> = {};
+  if (opts.dryRun) body.dry_run = true;
+
+  const result = await apiFetch<ConsolidateOutput>("/api/v1/consolidate/op", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+
+  if (spinner) spinner.stop();
 
   if (!result.ok) {
-    if (result.status === 0) {
-      process.stderr.write(
-        `Error: ${result.message}\n`
-      );
+    if (opts.json) {
+      process.stderr.write(JSON.stringify({ error: result.message }) + "\n");
     } else {
-      process.stderr.write(
-        `Error: Consolidation failed (${result.status}): ${result.message}\n`
-      );
+      process.stderr.write(`Error: Consolidation failed (${result.status}): ${result.message}\n`);
     }
     process.exit(1);
   }
 
   if (opts.json) {
-    process.stdout.write(JSON.stringify(result.data, null, 2) + "\n");
+    process.stdout.write(JSON.stringify(result.data) + "\n");
     return;
   }
 
-  const { status } = result.data;
+  const data = result.data;
 
-  if (status === "no_seed") {
+  if (data.status === "no_seed") {
     process.stdout.write("No consolidation work available. Try again later.\n");
     return;
   }
 
-  if (status === "cluster_too_small") {
-    const { seed, candidateCount, debug } = result.data;
+  if (data.status === "cluster_too_small") {
     process.stdout.write(
-      `Seed: "${seed?.title}" (${seed?.id})\n` +
-        `Found only ${candidateCount} candidate(s), need at least 3. Try running with different content.\n`
+      `Seed: "${data.seed?.title}" (${data.seed?.id})\n` +
+        `Found only ${data.candidate_count} candidate(s), need at least 3. Try running with different content.\n`
     );
-    if (debug && (opts.verbose || candidateCount === 0)) {
-      process.stdout.write("\n" + formatDebug(debug) + "\n");
-    }
     return;
   }
 
-  if (status === "dry_run") {
-    const { seed, candidates, proposedInsightType, estimatedConfidence, debug } =
-      result.data;
-    process.stdout.write(`Seed: "${seed?.title}" (${seed?.id})\n`);
-    if (candidates && candidates.length > 0) {
-      process.stdout.write(`Candidates (${candidates.length}):\n`);
-      for (const c of candidates) {
+  if (data.status === "dry_run") {
+    process.stdout.write(`Seed: "${data.seed?.title}" (${data.seed?.id})\n`);
+    if (data.candidates && data.candidates.length > 0) {
+      process.stdout.write(`Candidates (${data.candidates.length}):\n`);
+      for (const c of data.candidates) {
         process.stdout.write(`  - "${c.title}" (score: ${c.score.toFixed(2)})\n`);
       }
     }
-    process.stdout.write(`Proposed type: ${proposedInsightType}\n`);
+    process.stdout.write(`Proposed type: ${data.proposed_insight_type}\n`);
     process.stdout.write(
-      `Estimated confidence: ${estimatedConfidence?.toFixed(2)}\n`
+      `Estimated confidence: ${data.estimated_confidence?.toFixed(2)}\n`
     );
-    if (debug && opts.verbose) {
-      process.stdout.write("\n" + formatDebug(debug) + "\n");
-    }
     return;
   }
 
-  if (status === "consolidated") {
-    const { seed, clusterSize, insightId } = result.data;
+  if (data.status === "consolidated") {
     process.stdout.write(
       [
         pc.green("Consolidation complete!"),
-        `Seed:         "${seed?.title}" (${seed?.id})`,
-        `Cluster Size: ${clusterSize}`,
-        `Insight ID:   ${insightId}`,
+        `Seed:         "${data.seed?.title}" (${data.seed?.id})`,
+        `Cluster Size: ${data.cluster_size}`,
+        `Insight ID:   ${data.insight_id}`,
       ].join("\n") + "\n"
     );
     return;
   }
 
-  // Fallback for any other status (e.g., retired_reeval)
-  process.stdout.write(`Consolidation result: ${status}\n`);
-  if (result.data.seed) {
+  // Fallback for any other status
+  process.stdout.write(`Consolidation result: ${data.status}\n`);
+  if (data.seed) {
     process.stdout.write(
-      `Seed: "${result.data.seed.title}" (${result.data.seed.id})\n`
+      `Seed: "${data.seed.title}" (${data.seed.id})\n`
     );
-  }
-  if (result.data.debug && opts.verbose) {
-    process.stdout.write("\n" + formatDebug(result.data.debug) + "\n");
   }
 }

--- a/apps/cli/src/commands/health.ts
+++ b/apps/cli/src/commands/health.ts
@@ -2,23 +2,38 @@ import pc from "picocolors";
 import { apiFetch } from "../api.ts";
 import { API_URL } from "../utils/env.ts";
 
-interface HealthResponse {
-  status: string;
+interface HealthOutput {
   version: string;
-  qmd: {
-    status: string;
-    doc_count?: number;
-    collections?: number;
-    needs_embedding?: number;
+  memories: {
+    total: number;
+    by_type: Record<string, number>;
   };
-  queue_length: number;
+  queue: {
+    pending: number;
+    processing: number;
+    failed: number;
+  };
+  index: {
+    documents: number;
+    embedded: number;
+    status: string;
+  };
+  sync?: {
+    apple_notes: {
+      enabled: boolean;
+      last_sync_at?: string;
+      total_tracked: number;
+    };
+  };
 }
 
 export async function healthCommand(opts: { json: boolean }): Promise<void> {
-  const result = await apiFetch<HealthResponse>("/api/v1/health");
+  const result = await apiFetch<HealthOutput>("/api/v1/health");
 
   if (!result.ok) {
-    if (result.status === 0) {
+    if (opts.json) {
+      process.stderr.write(JSON.stringify({ error: result.message }) + "\n");
+    } else if (result.status === 0) {
       process.stderr.write(`Error: ${result.message}\n`);
     } else {
       process.stderr.write(
@@ -29,35 +44,50 @@ export async function healthCommand(opts: { json: boolean }): Promise<void> {
   }
 
   if (opts.json) {
-    process.stdout.write(JSON.stringify(result.data, null, 2) + "\n");
+    process.stdout.write(JSON.stringify(result.data) + "\n");
     return;
   }
 
-  const { status, version, qmd, queue_length } = result.data;
-  const statusColor = status === "ok" ? pc.green(status) : pc.red(status);
-  
-  // Guard against missing `qmd` if server returns old structure temporarily
-  const qmdStatus = qmd?.status || "undefined";
-  const qmdColor =
-    qmdStatus === "ok" ? pc.green(qmdStatus) : pc.yellow(qmdStatus);
-    
-  let qmdDetails = "";
-  if (qmd) {
-    const details = [];
-    if (qmd.doc_count !== undefined) details.push(`docs: ${qmd.doc_count}`);
-    if (qmd.collections !== undefined) details.push(`collections: ${qmd.collections}`);
-    if (qmd.needs_embedding) details.push(`needs embedding: ${qmd.needs_embedding}`);
-    if (details.length > 0) {
-      qmdDetails = ` (${details.join(", ")})`;
-    }
+  const { version, memories, queue, index, sync } = result.data;
+  const indexColor = index.status === "ok" ? pc.green(index.status) : pc.yellow(index.status);
+
+  const lines = [
+    `Version:      ${version}`,
+    ``,
+    pc.bold("Memories"),
+    `  Total:      ${memories.total}`,
+  ];
+
+  // Memory counts by type
+  for (const [type, count] of Object.entries(memories.by_type)) {
+    lines.push(`  ${type}: ${count}`);
   }
 
-  process.stdout.write(
-    [
-      `API Status:   ${statusColor}`,
-      `Version:      ${version}`,
-      `QMD Status:   ${qmdColor}${qmdDetails}`,
-      `Queue Length: ${queue_length}`,
-    ].join("\n") + "\n"
+  lines.push(
+    ``,
+    pc.bold("Queue"),
+    `  Pending:    ${queue.pending}`,
+    `  Processing: ${queue.processing}`,
+    `  Failed:     ${queue.failed}`,
+    ``,
+    pc.bold("Index"),
+    `  Status:     ${indexColor}`,
+    `  Documents:  ${index.documents}`,
+    `  Embedded:   ${index.embedded}`,
   );
+
+  // Sync state
+  if (sync?.apple_notes) {
+    const an = sync.apple_notes;
+    const enabledStr = an.enabled ? pc.green("enabled") : pc.dim("disabled");
+    lines.push(
+      ``,
+      pc.bold("Sync"),
+      `  Apple Notes: ${enabledStr}`,
+    );
+    if (an.last_sync_at) lines.push(`  Last Sync:   ${an.last_sync_at}`);
+    lines.push(`  Tracked:     ${an.total_tracked}`);
+  }
+
+  process.stdout.write(lines.join("\n") + "\n");
 }

--- a/apps/cli/src/commands/ingest.ts
+++ b/apps/cli/src/commands/ingest.ts
@@ -2,8 +2,10 @@ import pc from "picocolors";
 import { createSpinner } from "nanospinner";
 import { apiFetch } from "../api.ts";
 
-interface IngestResponse {
+interface RememberOutput {
   task_id: string;
+  status: "queued";
+  message: string;
 }
 
 interface TaskResponse {
@@ -21,6 +23,8 @@ interface IngestOpts {
   priority: string;
   wait: boolean;
   json: boolean;
+  suggestedTags?: string;
+  suggestedCategory?: string;
 }
 
 async function readStdin(): Promise<string> {
@@ -42,11 +46,11 @@ async function submitIngest(
     source,
     priority: opts.priority,
   };
-  if (opts.url) {
-    body.original_url = opts.url;
-  }
+  if (opts.url) body.url = opts.url;
+  if (opts.suggestedTags) body.suggested_tags = opts.suggestedTags.split(",").map((t) => t.trim());
+  if (opts.suggestedCategory) body.suggested_category = opts.suggestedCategory;
 
-  const result = await apiFetch<IngestResponse>("/api/v1/ingest/raw", {
+  const result = await apiFetch<RememberOutput>("/api/v1/remember", {
     method: "POST",
     body: JSON.stringify(body),
   });
@@ -113,18 +117,22 @@ export async function ingestCommand(
 
     const result = await submitIngest(content, source, opts);
     if ("error" in result) {
-      process.stderr.write(`Error: ${result.error}\n`);
+      if (opts.json) {
+        process.stderr.write(JSON.stringify({ error: result.error }) + "\n");
+      } else {
+        process.stderr.write(`Error: ${result.error}\n`);
+      }
       process.exit(1);
     }
 
     if (!opts.wait) {
       if (opts.json) {
         process.stdout.write(
-          JSON.stringify({ task_id: result.taskId, source }) + "\n"
+          JSON.stringify({ task_id: result.taskId, status: "queued", source }) + "\n"
         );
       } else {
         process.stdout.write(
-          `Queued task ${result.taskId} (source: "${source}"). Check status: kore status ${result.taskId}\n`
+          `Queued task ${result.taskId} (source: "${source}"). Check status: kore task ${result.taskId}\n`
         );
       }
       return;
@@ -162,11 +170,11 @@ export async function ingestCommand(
     if (!opts.wait) {
       if (opts.json) {
         process.stdout.write(
-          JSON.stringify({ task_id: result.taskId, source }) + "\n"
+          JSON.stringify({ task_id: result.taskId, status: "queued", source }) + "\n"
         );
       } else {
         process.stdout.write(
-          `Queued task ${result.taskId} (source: "${source}"). Check status: kore status ${result.taskId}\n`
+          `Queued task ${result.taskId} (source: "${source}"). Check status: kore task ${result.taskId}\n`
         );
       }
       succeeded++;

--- a/apps/cli/src/commands/insights.ts
+++ b/apps/cli/src/commands/insights.ts
@@ -1,0 +1,93 @@
+import pc from "picocolors";
+import { apiFetch } from "../api.ts";
+
+interface InsightResultItem {
+  id: string;
+  title: string;
+  insight_type: string;
+  confidence: number;
+  status: string;
+  source_ids: string[];
+  source_count: number;
+  synthesis: string;
+  distilled_items: string[];
+  tags: string[];
+  date_saved: string;
+  last_synthesized_at?: string;
+  reinforcement_count: number;
+  supersedes?: string[];
+}
+
+interface InsightsOutput {
+  results: InsightResultItem[];
+  total: number;
+}
+
+interface InsightsOpts {
+  type?: string;
+  status?: string;
+  limit?: string;
+  json: boolean;
+}
+
+export async function insightsCommand(
+  query: string | undefined,
+  opts: InsightsOpts
+): Promise<void> {
+  const params = new URLSearchParams();
+  if (query?.trim()) params.set("query", query.trim());
+  if (opts.type) params.set("type", opts.type);
+  if (opts.status) params.set("status", opts.status);
+  if (opts.limit) params.set("limit", opts.limit);
+
+  const qs = params.toString();
+  const path = `/api/v1/insights${qs ? `?${qs}` : ""}`;
+
+  const result = await apiFetch<InsightsOutput>(path);
+
+  if (!result.ok) {
+    if (opts.json) {
+      process.stderr.write(JSON.stringify({ error: result.message }) + "\n");
+    } else {
+      process.stderr.write(`Error: ${result.message}\n`);
+    }
+    process.exit(1);
+  }
+
+  const data = result.data;
+
+  if (opts.json) {
+    process.stdout.write(JSON.stringify(data) + "\n");
+    return;
+  }
+
+  if (data.results.length === 0) {
+    process.stdout.write("No insights found.\n");
+    return;
+  }
+
+  for (let i = 0; i < data.results.length; i++) {
+    const r = data.results[i];
+    const confStr = pc.dim(`confidence: ${r.confidence.toFixed(2)}`);
+    const typeStr = pc.dim(`[${r.insight_type}]`);
+    const statusStr = r.status === "active" ? pc.green(r.status) : pc.yellow(r.status);
+
+    const lines = [
+      pc.bold(pc.cyan(r.title)) + "  " + typeStr + "  " + confStr,
+      `  Status: ${statusStr}  Sources: ${r.source_count}  Reinforced: ${r.reinforcement_count}x`,
+      pc.dim(`  id: ${r.id}`),
+    ];
+
+    if (r.synthesis) {
+      const synth = r.synthesis.length > 200 ? r.synthesis.slice(0, 200) + "..." : r.synthesis;
+      lines.push(`  ${synth}`);
+    }
+
+    process.stdout.write(lines.join("\n") + "\n");
+    if (i < data.results.length - 1) {
+      process.stdout.write(pc.dim("───") + "\n");
+    }
+  }
+
+  process.stdout.write(pc.dim(`\n${data.total} insight(s) found`) + "\n");
+}

--- a/apps/cli/src/commands/search.ts
+++ b/apps/cli/src/commands/search.ts
@@ -1,20 +1,42 @@
 import pc from "picocolors";
 import { apiFetch } from "../api.ts";
 
-interface SearchResult {
-  id: string | null;
-  path: string;
+interface RecallResultItem {
+  id: string;
   title: string;
-  snippet: string;
+  type: string;
+  category: string;
+  intent?: string;
+  confidence?: number;
+  tags: string[];
+  date_saved: string;
+  source: string;
+  distilled_items: string[];
   score: number;
-  collection: string | null;
+  insight_type?: string;
+  source_count?: number;
+  status?: string;
+}
+
+interface RecallOutput {
+  results: RecallResultItem[];
+  query: string;
+  total: number;
+  offset: number;
+  has_more: boolean;
 }
 
 interface SearchOpts {
   intent?: string;
   limit?: string;
-  collection?: string;
+  type?: string;
+  tags?: string;
+  minConfidence?: string;
   minScore?: string;
+  includeInsights?: boolean;
+  createdAfter?: string;
+  createdBefore?: string;
+  offset?: string;
   json: boolean;
 }
 
@@ -25,7 +47,7 @@ export async function searchCommand(
   // If no query supplied, prompt interactively
   let resolvedQuery = query?.trim() ?? "";
 
-  if (!resolvedQuery) {
+  if (!resolvedQuery && process.stdin.isTTY) {
     const { prompt } = await import("enquirer");
     const answer = await prompt<{ query: string }>({
       type: "input",
@@ -33,69 +55,72 @@ export async function searchCommand(
       message: "Search query:",
     });
     resolvedQuery = answer.query.trim();
-    if (!resolvedQuery) {
-      process.stderr.write("Error: query cannot be empty.\n");
-      process.exit(1);
-    }
   }
 
-  const body: Record<string, unknown> = { query: resolvedQuery };
+  // Build recall request body
+  const body: Record<string, unknown> = {};
+  if (resolvedQuery) body.query = resolvedQuery;
+  if (opts.type) body.type = opts.type;
   if (opts.intent) body.intent = opts.intent;
+  if (opts.tags) body.tags = opts.tags.split(",").map((t) => t.trim());
   if (opts.limit) body.limit = Number(opts.limit);
-  if (opts.collection) body.collection = opts.collection;
-  if (opts.minScore !== undefined) body.minScore = Number(opts.minScore);
+  if (opts.minConfidence) body.min_confidence = Number(opts.minConfidence);
+  if (opts.minScore) body.min_score = Number(opts.minScore);
+  if (opts.includeInsights !== undefined) body.include_insights = opts.includeInsights;
+  if (opts.createdAfter) body.created_after = opts.createdAfter;
+  if (opts.createdBefore) body.created_before = opts.createdBefore;
+  if (opts.offset) body.offset = Number(opts.offset);
 
-  const result = await apiFetch<SearchResult[]>("/api/v1/search", {
+  const result = await apiFetch<RecallOutput>("/api/v1/recall", {
     method: "POST",
     body: JSON.stringify(body),
   });
 
   if (!result.ok) {
-    if (result.status === 0) {
-      process.stderr.write(`Error: ${result.message}\n`);
+    if (opts.json) {
+      process.stderr.write(JSON.stringify({ error: result.message }) + "\n");
     } else {
-      process.stderr.write(
-        `Error: ${result.message || `API error (${result.status})`}\n`
-      );
+      process.stderr.write(`Error: ${result.message}\n`);
     }
     process.exit(1);
   }
 
-  const results = result.data;
+  const data = result.data;
 
   // ── JSON output ──────────────────────────────────────────────────────
   if (opts.json) {
-    process.stdout.write(
-      JSON.stringify({ query: resolvedQuery, results }, null, 2) + "\n"
-    );
+    process.stdout.write(JSON.stringify(data) + "\n");
     return;
   }
 
   // ── Empty results ────────────────────────────────────────────────────
-  if (results.length === 0) {
-    process.stdout.write(`No results found for '${resolvedQuery}'\n`);
+  if (data.results.length === 0) {
+    const queryStr = data.query ? ` for '${data.query}'` : "";
+    process.stdout.write(`No results found${queryStr}\n`);
     return;
   }
 
-  // ── Formatted output ────────────────────────────────────────────────
-  for (let i = 0; i < results.length; i++) {
-    const r = results[i];
-    const snippet =
-      r.snippet && r.snippet.length > 200
-        ? r.snippet.slice(0, 200) + "..."
-        : r.snippet ?? "";
-
+  // ── Formatted output ─────────────────────────────────────────────────
+  for (let i = 0; i < data.results.length; i++) {
+    const r = data.results[i];
     const scoreStr = pc.dim(`score: ${r.score.toFixed(3)}`);
-    process.stdout.write(
-      [
-        pc.bold(pc.cyan(r.title)) + "  " + scoreStr,
-        pc.dim(r.path),
-        snippet,
-      ].join("\n") + "\n"
-    );
+    const typeStr = pc.dim(`[${r.type}]`);
+    const lines = [
+      pc.bold(pc.cyan(r.title)) + "  " + typeStr + "  " + scoreStr,
+      pc.dim(`id: ${r.id}`),
+    ];
 
-    if (i < results.length - 1) {
+    if (r.distilled_items.length > 0) {
+      lines.push(r.distilled_items.slice(0, 3).map((d) => `  - ${d}`).join("\n"));
+    }
+
+    process.stdout.write(lines.join("\n") + "\n");
+    if (i < data.results.length - 1) {
       process.stdout.write(pc.dim("───") + "\n");
     }
+  }
+
+  if (data.has_more) {
+    process.stdout.write(pc.dim(`\n… more results available (use --offset ${data.offset + data.results.length})`) + "\n");
   }
 }

--- a/apps/cli/src/commands/show.ts
+++ b/apps/cli/src/commands/show.ts
@@ -1,15 +1,29 @@
+import pc from "picocolors";
 import { apiFetch } from "../api.ts";
 
-interface MemoryFull {
+interface InspectOutput {
   id: string;
+  title: string;
   type: string;
   category: string;
-  date_saved: string;
-  source: string;
+  intent?: string;
+  confidence?: number;
   tags: string[];
+  date_saved: string;
+  date_created?: string;
+  date_modified?: string;
+  source: string;
   url?: string;
-  title: string;
+  distilled_items: string[];
   content: string;
+  consolidated_at?: string;
+  insight_refs?: string[];
+  insight_type?: string;
+  source_ids?: string[];
+  supersedes?: string[];
+  superseded_by?: string[];
+  status?: string;
+  reinforcement_count?: number;
 }
 
 interface ShowOpts {
@@ -17,23 +31,24 @@ interface ShowOpts {
 }
 
 export async function showCommand(id: string, opts: ShowOpts): Promise<void> {
-  const result = await apiFetch<MemoryFull>(`/api/v1/memory/${id}`);
+  const result = await apiFetch<InspectOutput>(`/api/v1/inspect/${id}`);
 
   if (!result.ok) {
-    if (result.status === 404) {
+    if (opts.json) {
+      process.stderr.write(JSON.stringify({ error: result.message }) + "\n");
+    } else if (result.status === 404) {
       process.stderr.write(`Error: Memory ${id} not found.\n`);
-    } else if (result.status === 0) {
-      process.stderr.write(`Error: ${result.message}\n`);
     } else {
-      process.stderr.write(`Error: API error (${result.status}): ${result.message}\n`);
+      process.stderr.write(`Error: ${result.message}\n`);
     }
     process.exit(1);
   }
 
   if (opts.json) {
-    process.stdout.write(JSON.stringify(result.data, null, 2) + "\n");
+    process.stdout.write(JSON.stringify(result.data) + "\n");
     return;
   }
 
+  // Human-readable output: show the raw content (backward-compatible)
   process.stdout.write(result.data.content + "\n");
 }

--- a/apps/cli/src/commands/task.ts
+++ b/apps/cli/src/commands/task.ts
@@ -11,21 +11,19 @@ interface TaskResponse {
   [key: string]: unknown;
 }
 
-export async function statusCommand(
+export async function taskCommand(
   taskId: string,
   opts: { json: boolean }
 ): Promise<void> {
   const result = await apiFetch<TaskResponse>(`/api/v1/task/${taskId}`);
 
   if (!result.ok) {
-    if (result.status === 404) {
+    if (opts.json) {
+      process.stderr.write(JSON.stringify({ error: result.message }) + "\n");
+    } else if (result.status === 404) {
       process.stderr.write(`Error: Task ${taskId} not found.\n`);
-    } else if (result.status === 0) {
-      process.stderr.write(`Error: ${result.message}\n`);
     } else {
-      process.stderr.write(
-        `Error: Failed to fetch task ${taskId} (${result.status}): ${result.message}\n`
-      );
+      process.stderr.write(`Error: ${result.message}\n`);
     }
     process.exit(1);
   }
@@ -33,7 +31,7 @@ export async function statusCommand(
   const task = result.data;
 
   if (opts.json) {
-    process.stdout.write(JSON.stringify(task, null, 2) + "\n");
+    process.stdout.write(JSON.stringify(task) + "\n");
     return;
   }
 

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -4,7 +4,7 @@ import { warnIfNoApiKey } from "./utils/env.ts";
 import { healthCommand } from "./commands/health.ts";
 import { configCommand } from "./commands/config.ts";
 import { ingestCommand } from "./commands/ingest.ts";
-import { statusCommand } from "./commands/status.ts";
+import { taskCommand } from "./commands/task.ts";
 import { listCommand } from "./commands/list.ts";
 import { showCommand } from "./commands/show.ts";
 import { deleteCommand } from "./commands/delete.ts";
@@ -13,6 +13,7 @@ import { resetCommand } from "./commands/reset.ts";
 import { syncCommand } from "./commands/sync.ts";
 import { consolidateCommand } from "./commands/consolidate.ts";
 import { consolidationResetCommand } from "./commands/consolidation-reset.ts";
+import { insightsCommand } from "./commands/insights.ts";
 
 // Read version from package.json
 const pkg = await import("../package.json", { with: { type: "json" } });
@@ -36,7 +37,7 @@ program.hook("preAction", (thisCommand) => {
 // ─── health ──────────────────────────────────────────────────────────────────
 program
   .command("health")
-  .description("Check the health of the Kore API")
+  .description("Check system health: memory counts, queue, index, and sync state")
   .option("--json", "Output raw JSON", false)
   .action(async (opts) => {
     await healthCommand(opts);
@@ -60,19 +61,21 @@ program
   .option("--url <url>", "Attach an original URL to the ingestion payload")
   .option("--priority <level>", "Queue priority: low, normal, high", "normal")
   .option("--no-wait", "Skip polling and return immediately")
+  .option("--suggested-tags <tags>", "Comma-separated suggested tags")
+  .option("--suggested-category <category>", "Suggested category")
   .option("--json", "Output JSON (with --no-wait)", false)
   .action(async (files, opts) => {
     await ingestCommand(files, opts);
   });
 
-// ─── status ─────────────────────────────────────────────────────────────────
+// ─── task ────────────────────────────────────────────────────────────────────
 program
-  .command("status")
+  .command("task")
   .description("Check the status of an ingestion task")
-  .argument("<task-id>", "Task ID to check")
+  .argument("<id>", "Task ID to check")
   .option("--json", "Output raw JSON", false)
   .action(async (taskId, opts) => {
-    await statusCommand(taskId, opts);
+    await taskCommand(taskId, opts);
   });
 
 // ─── list ────────────────────────────────────────────────────────────────────
@@ -89,9 +92,9 @@ program
 // ─── show ────────────────────────────────────────────────────────────────────
 program
   .command("show")
-  .description("Show a stored memory")
+  .description("Show a stored memory with full details")
   .argument("<id>", "Memory ID (or prefix)")
-  .option("--json", "Output raw JSON", false)
+  .option("--json", "Output raw JSON matching InspectOutput schema", false)
   .action(async (id, opts) => {
     await showCommand(id, opts);
   });
@@ -109,15 +112,34 @@ program
 // ─── search ──────────────────────────────────────────────────────────────────
 program
   .command("search")
-  .description("Search memories using semantic search")
+  .description("Search memories using semantic search (backed by recall operation)")
   .argument("[query]", "Search query (prompted interactively if omitted)")
+  .option("--type <type>", "Filter by memory type")
   .option("--intent <string>", "Hint for the reranker")
+  .option("--tags <tags>", "Comma-separated tag filter (all must match)")
   .option("--limit <number>", "Max results to return", "10")
-  .option("--collection <string>", "Filter by collection")
+  .option("--min-confidence <number>", "Minimum confidence threshold (0.0 to 1.0)")
   .option("--min-score <number>", "Minimum score threshold (0.0 to 1.0)")
-  .option("--json", "Output results as JSON", false)
+  .option("--include-insights", "Include insight memories in results")
+  .option("--created-after <date>", "Filter to memories created after this date (ISO 8601)")
+  .option("--created-before <date>", "Filter to memories created before this date (ISO 8601)")
+  .option("--offset <number>", "Pagination offset", "0")
+  .option("--json", "Output results as JSON matching RecallOutput schema", false)
   .action(async (query, opts) => {
     await searchCommand(query, opts);
+  });
+
+// ─── insights ────────────────────────────────────────────────────────────────
+program
+  .command("insights")
+  .description("List or search synthesized insights")
+  .argument("[query]", "Optional search query")
+  .option("--type <type>", "Filter by insight type (e.g., evolution, pattern, preference)")
+  .option("--status <status>", "Filter by status (default: active)", "active")
+  .option("--limit <number>", "Max results to return", "5")
+  .option("--json", "Output results as JSON matching InsightsOutput schema", false)
+  .action(async (query, opts) => {
+    await insightsCommand(query, opts);
   });
 
 // ─── sync ───────────────────────────────────────────────────────────────────
@@ -136,8 +158,8 @@ program
   .description("Trigger a consolidation cycle to synthesize related memories into insights")
   .option("--dry-run", "Preview consolidation without running LLM synthesis", false)
   .option("--reset-failed", "Reset failed tracker entries before running", false)
-  .option("-v, --verbose", "Show detailed diagnostic info (query, scores, filter stats)", false)
-  .option("--json", "Output raw JSON", false)
+  .option("-v, --verbose", "Show detailed diagnostic info", false)
+  .option("--json", "Output raw JSON matching ConsolidateOutput schema", false)
   .action(async (opts) => {
     await consolidateCommand({ dryRun: opts.dryRun, resetFailed: opts.resetFailed, json: opts.json, verbose: opts.verbose });
   });

--- a/apps/cli/tests/cli-alignment.test.ts
+++ b/apps/cli/tests/cli-alignment.test.ts
@@ -1,0 +1,608 @@
+import { test, expect, describe, afterAll } from "bun:test";
+import { serve } from "bun";
+
+const CLI = `${import.meta.dir}/../src/index.ts`;
+
+function runCliWithPort(port: number, ...args: string[]) {
+  return Bun.spawn(["bun", CLI, ...args], {
+    env: {
+      ...process.env,
+      KORE_API_URL: `http://127.0.0.1:${port}`,
+      KORE_API_KEY: "test-key",
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+// ─── Search (recall) Command ─────────────────────────────────────────────────
+
+describe("search command (recall operation)", () => {
+  const recallResponse = {
+    results: [
+      {
+        id: "mem-001",
+        title: "Tokyo Ramen",
+        type: "place",
+        category: "food",
+        tags: ["japan", "food"],
+        date_saved: "2026-03-10T00:00:00Z",
+        source: "manual",
+        distilled_items: ["Famous ramen shop in Shinjuku", "Rich tonkotsu broth"],
+        score: 0.95,
+      },
+      {
+        id: "mem-002",
+        title: "Japan Travel Notes",
+        type: "note",
+        category: "travel",
+        tags: ["japan"],
+        date_saved: "2026-03-09T00:00:00Z",
+        source: "apple_notes",
+        distilled_items: [],
+        score: 0.82,
+      },
+    ],
+    query: "ramen",
+    total: 2,
+    offset: 0,
+    has_more: false,
+  };
+
+  const recallServer = serve({
+    port: 18900,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/v1/recall" && req.method === "POST") {
+        return (async () => {
+          const body = (await req.json()) as Record<string, unknown>;
+          // If type filter applied, filter results
+          if (body.type === "place") {
+            return new Response(JSON.stringify({
+              ...recallResponse,
+              results: recallResponse.results.filter(r => r.type === "place"),
+              total: 1,
+            }), { headers: { "Content-Type": "application/json" } });
+          }
+          if (body.query === "empty") {
+            return new Response(JSON.stringify({
+              results: [], query: "empty", total: 0, offset: 0, has_more: false,
+            }), { headers: { "Content-Type": "application/json" } });
+          }
+          return new Response(JSON.stringify(recallResponse), {
+            headers: { "Content-Type": "application/json" },
+          });
+        })();
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  afterAll(() => recallServer.stop());
+
+  test("search --json outputs RecallOutput schema", async () => {
+    const proc = runCliWithPort(18900, "search", "ramen", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.query).toBe("ramen");
+    expect(data.total).toBe(2);
+    expect(data.offset).toBe(0);
+    expect(data.has_more).toBe(false);
+    expect(data.results).toHaveLength(2);
+    expect(data.results[0].id).toBe("mem-001");
+    expect(data.results[0].distilled_items).toHaveLength(2);
+    expect(data.results[0].type).toBe("place");
+    expect(data.results[0].score).toBe(0.95);
+  });
+
+  test("search with --type filter", async () => {
+    const proc = runCliWithPort(18900, "search", "ramen", "--type", "place", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].type).toBe("place");
+  });
+
+  test("search formatted output shows titles and scores", async () => {
+    const proc = runCliWithPort(18900, "search", "ramen");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("Tokyo Ramen");
+    expect(out).toContain("[place]");
+    expect(out).toContain("score: 0.950");
+    expect(out).toContain("Famous ramen shop");
+  });
+
+  test("search empty results", async () => {
+    const proc = runCliWithPort(18900, "search", "empty");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("No results found");
+  });
+
+  test("search --json error outputs JSON to stderr", async () => {
+    const proc = runCliWithPort(19000, "search", "ramen", "--json");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).toBe(1);
+    const data = JSON.parse(stderr);
+    expect(data.error).toBeDefined();
+  });
+});
+
+// ─── Show (inspect) Command ──────────────────────────────────────────────────
+
+describe("show command (inspect operation)", () => {
+  const inspectOutput = {
+    id: "mem-001",
+    title: "Tokyo Ramen",
+    type: "place",
+    category: "food",
+    tags: ["japan", "food"],
+    date_saved: "2026-03-10T00:00:00Z",
+    source: "manual",
+    distilled_items: ["Famous ramen shop", "Rich broth"],
+    content: "---\nid: mem-001\ntype: place\n---\n\n# Tokyo Ramen\n\nBody text here.\n",
+    url: "https://example.com",
+  };
+
+  const inspectServer = serve({
+    port: 18901,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/v1/inspect/mem-001") {
+        return new Response(JSON.stringify(inspectOutput), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.pathname.startsWith("/api/v1/inspect/")) {
+        return new Response(JSON.stringify({ error: "Memory not found", code: "NOT_FOUND" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  afterAll(() => inspectServer.stop());
+
+  test("show --json outputs InspectOutput schema", async () => {
+    const proc = runCliWithPort(18901, "show", "mem-001", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.id).toBe("mem-001");
+    expect(data.title).toBe("Tokyo Ramen");
+    expect(data.type).toBe("place");
+    expect(data.distilled_items).toHaveLength(2);
+    expect(data.content).toContain("# Tokyo Ramen");
+    expect(data.url).toBe("https://example.com");
+  });
+
+  test("show human-readable outputs content", async () => {
+    const proc = runCliWithPort(18901, "show", "mem-001");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("# Tokyo Ramen");
+    expect(out).toContain("Body text here.");
+  });
+
+  test("show not found exits 1", async () => {
+    const proc = runCliWithPort(18901, "show", "nonexistent");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("Memory nonexistent not found");
+  });
+
+  test("show --json not found outputs JSON to stderr", async () => {
+    const proc = runCliWithPort(18901, "show", "nonexistent", "--json");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).toBe(1);
+    const data = JSON.parse(stderr);
+    expect(data.error).toBeDefined();
+  });
+});
+
+// ─── Ingest (remember) Command ───────────────────────────────────────────────
+
+describe("ingest command (remember operation)", () => {
+  const rememberServer = serve({
+    port: 18902,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/v1/remember" && req.method === "POST") {
+        return new Response(JSON.stringify({
+          task_id: "task-new-001",
+          status: "queued",
+          message: "Memory queued for extraction.",
+        }), {
+          status: 202,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      if (url.pathname.startsWith("/api/v1/task/")) {
+        return new Response(JSON.stringify({
+          id: "task-new-001",
+          status: "completed",
+          source: "stdin",
+        }), { headers: { "Content-Type": "application/json" } });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  afterAll(() => rememberServer.stop());
+
+  test("ingest --no-wait --json outputs JSON", async () => {
+    const proc = Bun.spawn(["bun", CLI, "ingest", "--no-wait", "--json"], {
+      env: {
+        ...process.env,
+        KORE_API_URL: `http://127.0.0.1:18902`,
+        KORE_API_KEY: "test-key",
+      },
+      stdin: new TextEncoder().encode("Some text content"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.task_id).toBe("task-new-001");
+    expect(data.status).toBe("queued");
+  });
+
+  test("ingest --no-wait mentions kore task instead of kore status", async () => {
+    const proc = Bun.spawn(["bun", CLI, "ingest", "--no-wait"], {
+      env: {
+        ...process.env,
+        KORE_API_URL: `http://127.0.0.1:18902`,
+        KORE_API_KEY: "test-key",
+      },
+      stdin: new TextEncoder().encode("Content"),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("kore task");
+    expect(out).not.toContain("kore status");
+  });
+});
+
+// ─── Health Command ──────────────────────────────────────────────────────────
+
+describe("health command (health operation)", () => {
+  const healthResponse = {
+    version: "1.2.0",
+    memories: {
+      total: 42,
+      by_type: { note: 20, place: 15, person: 5, insight: 2 },
+    },
+    queue: { pending: 3, processing: 1, failed: 0 },
+    index: { documents: 42, embedded: 40, status: "ok" },
+    sync: {
+      apple_notes: { enabled: true, last_sync_at: "2026-03-10T00:00:00Z", total_tracked: 10 },
+    },
+  };
+
+  const healthServer = serve({
+    port: 18903,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/v1/health") {
+        return new Response(JSON.stringify(healthResponse), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  afterAll(() => healthServer.stop());
+
+  test("health --json outputs HealthOutput schema", async () => {
+    const proc = runCliWithPort(18903, "health", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.version).toBe("1.2.0");
+    expect(data.memories.total).toBe(42);
+    expect(data.memories.by_type.note).toBe(20);
+    expect(data.queue.pending).toBe(3);
+    expect(data.index.status).toBe("ok");
+    expect(data.sync.apple_notes.enabled).toBe(true);
+  });
+
+  test("health human-readable shows memory counts, queue, index, and sync", async () => {
+    const proc = runCliWithPort(18903, "health");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("Version:");
+    expect(out).toContain("1.2.0");
+    expect(out).toContain("Memories");
+    expect(out).toContain("Total:      42");
+    expect(out).toContain("note: 20");
+    expect(out).toContain("Queue");
+    expect(out).toContain("Pending:    3");
+    expect(out).toContain("Index");
+    expect(out).toContain("Documents:  42");
+    expect(out).toContain("Sync");
+    expect(out).toContain("Apple Notes:");
+  });
+
+  test("health --json error outputs JSON to stderr", async () => {
+    const proc = runCliWithPort(19000, "health", "--json");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).toBe(1);
+    const data = JSON.parse(stderr);
+    expect(data.error).toBeDefined();
+  });
+});
+
+// ─── Insights Command ────────────────────────────────────────────────────────
+
+describe("insights command", () => {
+  const insightsResponse = {
+    results: [
+      {
+        id: "ins-001",
+        title: "Food Preference Evolution",
+        insight_type: "evolution",
+        confidence: 0.85,
+        status: "active",
+        source_ids: ["mem-001", "mem-002", "mem-003"],
+        source_count: 3,
+        synthesis: "User's food preferences have evolved from casual dining to artisanal ramen.",
+        distilled_items: ["Prefers rich broth", "Visits ramen shops weekly"],
+        tags: ["food", "japan"],
+        date_saved: "2026-03-10T00:00:00Z",
+        reinforcement_count: 2,
+      },
+    ],
+    total: 1,
+  };
+
+  const insightsServer = serve({
+    port: 18904,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/v1/insights") {
+        return new Response(JSON.stringify(insightsResponse), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  afterAll(() => insightsServer.stop());
+
+  test("insights --json outputs InsightsOutput schema", async () => {
+    const proc = runCliWithPort(18904, "insights", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.total).toBe(1);
+    expect(data.results).toHaveLength(1);
+    expect(data.results[0].id).toBe("ins-001");
+    expect(data.results[0].insight_type).toBe("evolution");
+    expect(data.results[0].confidence).toBe(0.85);
+    expect(data.results[0].source_count).toBe(3);
+    expect(data.results[0].synthesis).toContain("artisanal ramen");
+  });
+
+  test("insights human-readable shows insight details", async () => {
+    const proc = runCliWithPort(18904, "insights");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("Food Preference Evolution");
+    expect(out).toContain("[evolution]");
+    expect(out).toContain("confidence: 0.85");
+    expect(out).toContain("Sources: 3");
+    expect(out).toContain("Reinforced: 2x");
+    expect(out).toContain("artisanal ramen");
+  });
+
+  test("insights with query sends query parameter", async () => {
+    const proc = runCliWithPort(18904, "insights", "food", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.results).toHaveLength(1);
+  });
+
+  test("insights --json error outputs JSON to stderr", async () => {
+    const proc = runCliWithPort(19000, "insights", "--json");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).toBe(1);
+    const data = JSON.parse(stderr);
+    expect(data.error).toBeDefined();
+  });
+});
+
+// ─── Consolidate Command ─────────────────────────────────────────────────────
+
+describe("consolidate command (consolidate operation)", () => {
+  const consolidateServer = serve({
+    port: 18905,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/v1/consolidate/op" && req.method === "POST") {
+        return (async () => {
+          const body = (await req.json()) as { dry_run?: boolean };
+          if (body.dry_run) {
+            return new Response(JSON.stringify({
+              status: "dry_run",
+              seed: { id: "mem-001", title: "Tokyo Ramen" },
+              candidates: [
+                { id: "mem-002", title: "Japan Travel", score: 0.85 },
+                { id: "mem-003", title: "Ramen Notes", score: 0.80 },
+              ],
+              proposed_insight_type: "evolution",
+              estimated_confidence: 0.82,
+              candidate_count: 2,
+            }), { headers: { "Content-Type": "application/json" } });
+          }
+          return new Response(JSON.stringify({
+            status: "consolidated",
+            seed: { id: "mem-001", title: "Tokyo Ramen" },
+            insight_id: "ins-new-001",
+            cluster_size: 3,
+          }), { headers: { "Content-Type": "application/json" } });
+        })();
+      }
+      if (url.pathname === "/api/v1/consolidate" && req.method === "POST") {
+        return new Response(JSON.stringify({ status: "ok" }), {
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  afterAll(() => consolidateServer.stop());
+
+  test("consolidate --json outputs ConsolidateOutput schema", async () => {
+    const proc = runCliWithPort(18905, "consolidate", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.status).toBe("consolidated");
+    expect(data.seed.id).toBe("mem-001");
+    expect(data.insight_id).toBe("ins-new-001");
+    expect(data.cluster_size).toBe(3);
+  });
+
+  test("consolidate --dry-run --json outputs dry run schema", async () => {
+    const proc = runCliWithPort(18905, "consolidate", "--dry-run", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.status).toBe("dry_run");
+    expect(data.seed.title).toBe("Tokyo Ramen");
+    expect(data.candidates).toHaveLength(2);
+    expect(data.proposed_insight_type).toBe("evolution");
+    expect(data.estimated_confidence).toBe(0.82);
+  });
+
+  test("consolidate human-readable shows result", async () => {
+    const proc = runCliWithPort(18905, "consolidate");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("Consolidation complete!");
+    expect(out).toContain("Tokyo Ramen");
+    expect(out).toContain("ins-new-001");
+  });
+});
+
+// ─── Task Command (renamed from status) ──────────────────────────────────────
+
+describe("task command (renamed from status)", () => {
+  const taskServer = serve({
+    port: 18906,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/api/v1/task/task-found-123") {
+        return new Response(JSON.stringify({
+          id: "task-found-123",
+          status: "completed",
+          source: "test.md",
+          created_at: "2026-03-10T00:00:00Z",
+          updated_at: "2026-03-10T00:00:01Z",
+        }), { headers: { "Content-Type": "application/json" } });
+      }
+      if (url.pathname.startsWith("/api/v1/task/")) {
+        return new Response(JSON.stringify({ error: "Task not found" }), {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+      return new Response("Not found", { status: 404 });
+    },
+  });
+
+  afterAll(() => taskServer.stop());
+
+  test("task command exists and replaces status", async () => {
+    const proc = runCliWithPort(18906, "task", "task-found-123");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    expect(out).toContain("task-found-123");
+    expect(out).toContain("completed");
+  });
+
+  test("task --json outputs JSON", async () => {
+    const proc = runCliWithPort(18906, "task", "task-found-123", "--json");
+    const exitCode = await proc.exited;
+    const out = await new Response(proc.stdout).text();
+
+    expect(exitCode).toBe(0);
+    const data = JSON.parse(out);
+    expect(data.id).toBe("task-found-123");
+    expect(data.status).toBe("completed");
+  });
+
+  test("task not found exits 1", async () => {
+    const proc = runCliWithPort(18906, "task", "nonexistent");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("not found");
+  });
+
+  test("status command no longer exists", async () => {
+    const proc = runCliWithPort(18906, "status", "task-found-123");
+    const exitCode = await proc.exited;
+    const stderr = await new Response(proc.stderr).text();
+
+    expect(exitCode).toBe(1);
+    expect(stderr).toContain("unknown command");
+  });
+});

--- a/apps/cli/tests/cli.test.ts
+++ b/apps/cli/tests/cli.test.ts
@@ -140,10 +140,10 @@ describe("health command", () => {
     fetch(req) {
       if (req.url.endsWith("/api/v1/health")) {
         return new Response(JSON.stringify({
-          status: "ok",
           version: "1.0",
-          qmd_status: "ok",
-          queue_length: 5
+          memories: { total: 10, by_type: { note: 5, place: 5 } },
+          queue: { pending: 5, processing: 0, failed: 0 },
+          index: { documents: 10, embedded: 10, status: "ok" },
         }), { headers: { "Content-Type": "application/json" } });
       }
       return new Response("Not found", { status: 404 });
@@ -166,9 +166,9 @@ describe("health command", () => {
     const exitCode = await proc.exited;
     expect(exitCode).toBe(0);
     const out = await new Response(proc.stdout).text();
-    expect(out).toContain("API Status:");
+    expect(out).toContain("Version:");
     expect(out).toContain("ok");
-    expect(out).toContain("Queue Length: 5");
+    expect(out).toContain("Pending:    5");
   });
 
   test("prints error and exits 1 when API is unreachable", async () => {
@@ -212,11 +212,11 @@ describe("ingest command", () => {
     fetch(req) {
       const url = new URL(req.url);
 
-      // POST /api/v1/ingest/raw → return task_id
-      if (url.pathname === "/api/v1/ingest/raw" && req.method === "POST") {
+      // POST /api/v1/remember → return task_id (new endpoint)
+      if (url.pathname === "/api/v1/remember" && req.method === "POST") {
         return new Response(
-          JSON.stringify({ task_id: "task-abc-123" }),
-          { headers: { "Content-Type": "application/json" } }
+          JSON.stringify({ task_id: "task-abc-123", status: "queued", message: "Memory queued." }),
+          { status: 202, headers: { "Content-Type": "application/json" } }
         );
       }
 
@@ -246,10 +246,10 @@ describe("ingest command", () => {
     fetch(req) {
       const url = new URL(req.url);
 
-      if (url.pathname === "/api/v1/ingest/raw" && req.method === "POST") {
+      if (url.pathname === "/api/v1/remember" && req.method === "POST") {
         return new Response(
-          JSON.stringify({ task_id: "task-fail-456" }),
-          { headers: { "Content-Type": "application/json" } }
+          JSON.stringify({ task_id: "task-fail-456", status: "queued", message: "Memory queued." }),
+          { status: 202, headers: { "Content-Type": "application/json" } }
         );
       }
 
@@ -291,7 +291,7 @@ describe("ingest command", () => {
 
     expect(exitCode).toBe(0);
     expect(out).toContain("Queued task task-abc-123");
-    expect(out).toContain("kore status task-abc-123");
+    expect(out).toContain("kore task task-abc-123");
   });
 
   test("single file ingest with --no-wait --json outputs JSON", async () => {
@@ -407,9 +407,9 @@ describe("ingest command", () => {
   });
 });
 
-// ─── Status Command ─────────────────────────────────────────────────────────
+// ─── Task Command (was Status) ──────────────────────────────────────────────
 
-describe("status command", () => {
+describe("task command", () => {
   const statusServer = serve({
     port: 19993,
     fetch(req) {
@@ -441,7 +441,7 @@ describe("status command", () => {
   });
 
   test("prints task status in human-readable format", async () => {
-    const proc = runCliWithPort(19993, "status", "task-found-123");
+    const proc = runCliWithPort(19993, "task", "task-found-123");
     const exitCode = await proc.exited;
     const out = await new Response(proc.stdout).text();
 
@@ -452,7 +452,7 @@ describe("status command", () => {
   });
 
   test("--json outputs raw JSON task object", async () => {
-    const proc = runCliWithPort(19993, "status", "task-found-123", "--json");
+    const proc = runCliWithPort(19993, "task", "task-found-123", "--json");
     const exitCode = await proc.exited;
     const out = await new Response(proc.stdout).text();
 
@@ -463,7 +463,7 @@ describe("status command", () => {
   });
 
   test("404 prints not found error and exits 1", async () => {
-    const proc = runCliWithPort(19993, "status", "task-not-found");
+    const proc = runCliWithPort(19993, "task", "task-not-found");
     const exitCode = await proc.exited;
     const stderr = await new Response(proc.stderr).text();
 
@@ -472,7 +472,7 @@ describe("status command", () => {
   });
 
   test("API connection failure prints error", async () => {
-    const proc = runCliWithPort(19994, "status", "some-task");
+    const proc = runCliWithPort(19994, "task", "some-task");
     const exitCode = await proc.exited;
     const stderr = await new Response(proc.stderr).text();
 
@@ -603,12 +603,12 @@ describe("show command", () => {
     port: 19990,
     fetch(req) {
       const url = new URL(req.url);
-      if (url.pathname === `/api/v1/memory/${fullMemory.id}`) {
+      if (url.pathname === `/api/v1/inspect/${fullMemory.id}`) {
         return new Response(JSON.stringify(fullMemory), {
           headers: { "Content-Type": "application/json" },
         });
       }
-      if (url.pathname.startsWith("/api/v1/memory/")) {
+      if (url.pathname.startsWith("/api/v1/inspect/")) {
         return new Response(JSON.stringify({ error: "Memory not found", code: "NOT_FOUND" }), {
           status: 404,
           headers: { "Content-Type": "application/json" },
@@ -757,56 +757,64 @@ describe("delete command", () => {
 // ─── Search Command ───────────────────────────────────────────────────────────
 
 describe("search command", () => {
+  const recallResponse = {
+    results: [
+      {
+        id: "mem-001",
+        title: "Tokyo Ramen Shop",
+        type: "place",
+        category: "food",
+        tags: ["japan"],
+        date_saved: "2026-03-10T00:00:00Z",
+        source: "manual",
+        distilled_items: ["Amazing ramen spot in Shinjuku with rich tonkotsu broth"],
+        score: 0.95,
+      },
+      {
+        id: "mem-002",
+        title: "Travel Notes: Japan Trip",
+        type: "note",
+        category: "travel",
+        tags: [],
+        date_saved: "2026-03-09T00:00:00Z",
+        source: "apple_notes",
+        distilled_items: ["Visited several ramen shops including the famous one"],
+        score: 0.85,
+      },
+    ],
+    query: "ramen",
+    total: 2,
+    offset: 0,
+    has_more: false,
+  };
+
   const searchServer = serve({
     port: 19988,
     fetch(req) {
       const url = new URL(req.url);
-      if (url.pathname === "/api/v1/search" && req.method === "POST") {
+      if (url.pathname === "/api/v1/recall" && req.method === "POST") {
         return (async () => {
-          const body = (await req.json()) as {
-            query: string;
-            collection?: string;
-            limit?: number;
-          };
+          const body = (await req.json()) as Record<string, unknown>;
           if (body.query === "error") {
-            return new Response(JSON.stringify({ error: "Search index not available", code: "UNAVAILABLE" }), {
+            return new Response(JSON.stringify({ error: "Search index not available" }), {
               status: 503,
               headers: { "Content-Type": "application/json" },
             });
           }
           if (body.query === "empty") {
-            return new Response(JSON.stringify([]), {
-              headers: { "Content-Type": "application/json" },
-            });
+            return new Response(JSON.stringify({
+              results: [], query: "empty", total: 0, offset: 0, has_more: false,
+            }), { headers: { "Content-Type": "application/json" } });
           }
-          const results = [
-            {
-              path: "data/places/tokyo-ramen.md",
-              title: "Tokyo Ramen Shop",
-              snippet: "Amazing ramen spot in Shinjuku with rich tonkotsu broth...",
-              score: 0.95,
-              collection: "places",
-            },
-            {
-              path: "data/notes/japan-trip.md",
-              title: "Travel Notes: Japan Trip",
-              snippet: "Visited several ramen shops including the famous one in...",
-              score: 0.85,
-              collection: "notes",
-            },
-          ];
-          
-          let filtered = results;
-          if (body.collection) {
-             filtered = filtered.filter(r => r.collection === body.collection);
-          }
+          let results = [...recallResponse.results];
           if (body.limit) {
-             filtered = filtered.slice(0, body.limit);
+            results = results.slice(0, body.limit as number);
           }
-
-          return new Response(JSON.stringify(filtered), {
-            headers: { "Content-Type": "application/json" },
-          });
+          return new Response(JSON.stringify({
+            ...recallResponse,
+            results,
+            total: results.length,
+          }), { headers: { "Content-Type": "application/json" } });
         })();
       }
       return new Response("Not found", { status: 404 });
@@ -824,54 +832,12 @@ describe("search command", () => {
 
     expect(exitCode).toBe(0);
     expect(out).toContain("Tokyo Ramen Shop");
-    expect(out).toContain("data/places/tokyo-ramen.md");
-    expect(out).toContain("Amazing ramen spot in Shinjuku");
     expect(out).toContain("Travel Notes: Japan Trip");
-    expect(out).toContain("data/notes/japan-trip.md");
     expect(out).toContain("───");
-  });
-
-  test("snippet truncated to 200 chars", async () => {
-    // Build a server with a long snippet inline
-    const longSnippetServer = serve({
-      port: 19989,
-      fetch() {
-        const results = [
-          {
-            path: "data/long.md",
-            title: "Long Snippet",
-            snippet: "A".repeat(250),
-            score: 0.9,
-            collection: null,
-          },
-        ];
-        return new Response(JSON.stringify(results), {
-          headers: { "Content-Type": "application/json" },
-        });
-      },
-    });
-    const proc = runCliWithPort(19989, "search", "long");
-    const exitCode = await proc.exited;
-    const out = await new Response(proc.stdout).text();
-    longSnippetServer.stop();
-
-    expect(exitCode).toBe(0);
-    expect(out).toContain("A".repeat(200) + "...");
-    expect(out).not.toContain("A".repeat(201) + "...");
   });
 
   test("--limit restricts results", async () => {
     const proc = runCliWithPort(19988, "search", "ramen", "--limit", "1");
-    const exitCode = await proc.exited;
-    const out = await new Response(proc.stdout).text();
-
-    expect(exitCode).toBe(0);
-    expect(out).toContain("Tokyo Ramen Shop");
-    expect(out).not.toContain("Travel Notes: Japan Trip");
-  });
-
-  test("--collection filters results", async () => {
-    const proc = runCliWithPort(19988, "search", "ramen", "--collection", "places");
     const exitCode = await proc.exited;
     const out = await new Response(proc.stdout).text();
 
@@ -891,6 +857,8 @@ describe("search command", () => {
     expect(Array.isArray(data.results)).toBe(true);
     expect(data.results.length).toBe(2);
     expect(data.results[0].title).toBe("Tokyo Ramen Shop");
+    expect(data.results[0].id).toBeDefined();
+    expect(data.results[0].type).toBeDefined();
   });
 
   test("empty results prints 'No results found'", async () => {
@@ -899,7 +867,7 @@ describe("search command", () => {
     const out = await new Response(proc.stdout).text();
 
     expect(exitCode).toBe(0);
-    expect(out).toContain("No results found for 'empty'");
+    expect(out).toContain("No results found");
   });
 
   test("API error gracefully exits with code 1", async () => {

--- a/apps/core-api/src/app.ts
+++ b/apps/core-api/src/app.ts
@@ -21,7 +21,8 @@ import type { ConsolidationDeps, ConsolidationHandle } from "./consolidation-loo
 import { runConsolidationCycle, runConsolidationDryRun, buildConsolidationDeps } from "./consolidation-loop";
 import { resetConsolidation } from "./consolidation-reset";
 import type { PluginRegistryRepository } from "./plugin-registry";
-import { health as healthOp } from "./operations";
+import { health as healthOp, recall, remember, inspect as inspectOp, insights as insightsOp, consolidate as consolidateOp } from "./operations";
+import type { RecallInput, InsightsInput, ConsolidateInput } from "./operations";
 
 // ─── Zod Schemas for request validation ─────────────────────────────
 
@@ -539,6 +540,104 @@ export function createApp(deps: AppDeps = {}) {
         if (loopHandle) loopHandle.resume();
       }
     })
+    // ─── Recall (shared operation) ─────────────────────────────────
+    .post("/api/v1/recall", async ({ body, set }) => {
+      if (!searchFn) {
+        set.status = 503;
+        return { error: "Search index not available" };
+      }
+      const params = (body ?? {}) as RecallInput;
+      try {
+        return await recall(params, {
+          memoryIndex,
+          qmdSearch: searchFn,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set.status = 500;
+        return { error: message };
+      }
+    }, { body: t.Any() })
+    // ─── Remember (shared operation) ──────────────────────────────
+    .post("/api/v1/remember", async ({ body, set }) => {
+      const params = body as { content?: string; source?: string; url?: string; priority?: string; suggested_tags?: string[]; suggested_category?: string };
+      if (!params?.content) {
+        set.status = 400;
+        return { error: "content is required", code: "VALIDATION_ERROR" };
+      }
+      try {
+        const result = await remember({
+          content: params.content,
+          source: params.source,
+          url: params.url,
+          priority: (params.priority as "low" | "normal" | "high") ?? "normal",
+          suggested_tags: params.suggested_tags,
+          suggested_category: params.suggested_category,
+        }, { queue });
+        set.status = 202;
+        return result;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set.status = 500;
+        return { error: message };
+      }
+    }, { body: t.Any() })
+    // ─── Inspect (shared operation) ──────────────────────────────
+    .get("/api/v1/inspect/:id", async ({ params, set }) => {
+      try {
+        const result = await inspectOp(params.id, { memoryIndex });
+        if (!result) {
+          set.status = 404;
+          return { error: "Memory not found", code: "NOT_FOUND" };
+        }
+        return result;
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set.status = 500;
+        return { error: message };
+      }
+    })
+    // ─── Insights (shared operation) ─────────────────────────────
+    .get("/api/v1/insights", async ({ query, set }) => {
+      if (!searchFn) {
+        set.status = 503;
+        return { error: "Search index not available" };
+      }
+      const params: InsightsInput = {};
+      if (query.query) params.query = query.query as string;
+      if (query.type) params.insight_type = query.type as string;
+      if (query.status) params.status = query.status as string;
+      if (query.limit) params.limit = Number(query.limit);
+      try {
+        return await insightsOp(params, {
+          dataPath,
+          qmdSearch: searchFn,
+          memoryIndex,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set.status = 500;
+        return { error: message };
+      }
+    })
+    // ─── Consolidate (shared operation) ──────────────────────────
+    .post("/api/v1/consolidate/op", async ({ body, set }) => {
+      const params = (body ?? {}) as ConsolidateInput;
+      try {
+        return await consolidateOp(params, {
+          dataPath,
+          qmdSearch: searchFn!,
+          consolidationTracker: deps.consolidationTracker,
+          memoryIndex,
+          eventDispatcher,
+          consolidationLoopHandle: deps.consolidationLoopHandle,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        set.status = 500;
+        return { error: message };
+      }
+    }, { body: t.Any() })
     // ─── Reset Consolidation ─────────────────────────────────────
     .delete("/api/v1/consolidation", async ({ set }) => {
       const tracker = deps.consolidationTracker;


### PR DESCRIPTION
Closes #85

### Summary
Refactored all CLI commands to call shared operations via new REST API endpoints. Added new /api/v1/recall, /api/v1/remember, /api/v1/inspect/:id, /api/v1/insights, and /api/v1/consolidate/op endpoints in core-api. Updated search, show, ingest, health, and consolidate CLI commands with new flags and --json output matching operation schemas. Added new 'kore insights' command. Renamed 'kore status' to 'kore task'. All 69 CLI tests pass, typecheck passes.
