### PR TITLE
feat: Add MCP stdio proxy and agent setup documentation (MCP-004)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,19 @@ CONSOLIDATION_MAX_ATTEMPTS=3
 # Falls back to OLLAMA_MODEL / LLM_MODEL if not set
 # KORE_SYNTHESIS_MODEL=
 
+# ─── MCP Server ────────────────────────────────────────────────────
+# Enable the embedded MCP server on core-api (default: true)
+KORE_MCP_ENABLED=true
+
+# HTTP route path for the MCP server (default: /mcp)
+KORE_MCP_PATH=/mcp
+
+# Default limit for recall results when called via MCP (default: 10)
+KORE_MCP_DEFAULT_RECALL_LIMIT=10
+
+# Minimum QMD relevance score for recall results (default: 0.0)
+KORE_MCP_MIN_SCORE=0.0
+
 # ─── Apple Notes Plugin ─────────────────────────────────────────────
 # Enable the Apple Notes sync plugin (requires Full Disk Access on macOS)
 KORE_APPLE_NOTES_ENABLED=false

--- a/apps/cli/src/commands/mcp.ts
+++ b/apps/cli/src/commands/mcp.ts
@@ -1,0 +1,23 @@
+import { resolve } from "node:path";
+
+export async function mcpCommand(): Promise<void> {
+  // Resolve the mcp-server entry point relative to the CLI package
+  const mcpServerPath = resolve(
+    import.meta.dir,
+    "..",
+    "..",
+    "..",
+    "mcp-server",
+    "index.ts"
+  );
+
+  // Spawn the stdio proxy, inheriting stdio so the MCP client can communicate
+  const proc = Bun.spawn(["bun", "run", mcpServerPath], {
+    stdio: ["inherit", "inherit", "inherit"],
+    env: { ...process.env },
+  });
+
+  // Forward exit code
+  const exitCode = await proc.exited;
+  process.exit(exitCode);
+}

--- a/apps/cli/src/index.ts
+++ b/apps/cli/src/index.ts
@@ -14,6 +14,7 @@ import { syncCommand } from "./commands/sync.ts";
 import { consolidateCommand } from "./commands/consolidate.ts";
 import { consolidationResetCommand } from "./commands/consolidation-reset.ts";
 import { insightsCommand } from "./commands/insights.ts";
+import { mcpCommand } from "./commands/mcp.ts";
 
 // Read version from package.json
 const pkg = await import("../package.json", { with: { type: "json" } });
@@ -140,6 +141,14 @@ program
   .option("--json", "Output results as JSON matching InsightsOutput schema", false)
   .action(async (query, opts) => {
     await insightsCommand(query, opts);
+  });
+
+// ─── mcp ────────────────────────────────────────────────────────────────────
+program
+  .command("mcp")
+  .description("Start the MCP stdio proxy for agent integration")
+  .action(async () => {
+    await mcpCommand();
   });
 
 // ─── sync ───────────────────────────────────────────────────────────────────

--- a/apps/mcp-server/index.ts
+++ b/apps/mcp-server/index.ts
@@ -1,0 +1,105 @@
+/**
+ * Kore MCP stdio-to-HTTP proxy
+ *
+ * Lightweight bridge that exposes Kore's embedded MCP server to stdio-based
+ * MCP clients (Claude Desktop, Claude Code, etc.). Connects to the running
+ * Kore daemon at KORE_API_URL/mcp using Streamable HTTP transport.
+ *
+ * This process contains NO tool logic — all business logic lives in core-api.
+ */
+
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import {
+  CallToolRequestSchema,
+  ListToolsRequestSchema,
+} from "@modelcontextprotocol/sdk/types.js";
+
+const KORE_API_URL = process.env.KORE_API_URL ?? "http://localhost:3000";
+const KORE_API_KEY = process.env.KORE_API_KEY ?? "";
+const MCP_PATH = process.env.KORE_MCP_PATH ?? "/mcp";
+
+// ── Health check ─────────────────────────────────────────────────────
+
+async function checkDaemonHealth(): Promise<void> {
+  const url = `${KORE_API_URL}/api/v1/health`;
+  const headers: Record<string, string> = {};
+  if (KORE_API_KEY) {
+    headers["Authorization"] = `Bearer ${KORE_API_KEY}`;
+  }
+
+  try {
+    const res = await fetch(url, { headers, signal: AbortSignal.timeout(5000) });
+    if (!res.ok) {
+      process.stderr.write(
+        `Kore daemon returned HTTP ${res.status}. Check KORE_API_KEY and ensure the server is running.\n`
+      );
+      process.exit(1);
+    }
+  } catch {
+    process.stderr.write(
+      "Kore daemon is not running. Start it with `kore start`.\n"
+    );
+    process.exit(1);
+  }
+}
+
+// ── Proxy setup ──────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  await checkDaemonHealth();
+
+  // Upstream: HTTP client connecting to daemon's /mcp endpoint
+  const mcpUrl = new URL(MCP_PATH, KORE_API_URL);
+  const authHeaders: Record<string, string> = {};
+  if (KORE_API_KEY) {
+    authHeaders["Authorization"] = `Bearer ${KORE_API_KEY}`;
+  }
+
+  const httpTransport = new StreamableHTTPClientTransport(mcpUrl, {
+    requestInit: { headers: authHeaders },
+  });
+
+  const upstream = new Client({ name: "kore-stdio-proxy", version: "1.0.0" });
+  await upstream.connect(httpTransport);
+
+  // Downstream: stdio server facing the MCP client (Claude, etc.)
+  const server = new Server(
+    { name: "kore", version: "1.0.0" },
+    { capabilities: { tools: {} } }
+  );
+
+  // Forward listTools
+  server.setRequestHandler(ListToolsRequestSchema, async () => {
+    const result = await upstream.listTools();
+    return { tools: result.tools };
+  });
+
+  // Forward callTool
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    const { name, arguments: args } = request.params;
+    const result = await upstream.callTool({ name, arguments: args });
+    return result;
+  });
+
+  // Connect stdio transport
+  const stdioTransport = new StdioServerTransport();
+  await server.connect(stdioTransport);
+
+  // Graceful shutdown
+  const cleanup = async () => {
+    await server.close();
+    await upstream.close();
+    process.exit(0);
+  };
+
+  process.on("SIGINT", cleanup);
+  process.on("SIGTERM", cleanup);
+}
+
+main().catch((err) => {
+  process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+  process.exit(1);
+});

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@kore/mcp-server",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "start": "bun run index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.27.1"
+  },
+  "devDependencies": {
+    "@types/bun": "latest"
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -47,6 +47,16 @@
         "zod": "^3.24.2",
       },
     },
+    "apps/mcp-server": {
+      "name": "@kore/mcp-server",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.27.1",
+      },
+      "devDependencies": {
+        "@types/bun": "latest",
+      },
+    },
     "packages/an-export": {
       "name": "@kore/an-export",
       "dependencies": {
@@ -136,6 +146,8 @@
     "@kore/core-api": ["@kore/core-api@workspace:apps/core-api"],
 
     "@kore/llm-extractor": ["@kore/llm-extractor@workspace:packages/llm-extractor"],
+
+    "@kore/mcp-server": ["@kore/mcp-server@workspace:apps/mcp-server"],
 
     "@kore/plugin-apple-notes": ["@kore/plugin-apple-notes@workspace:packages/plugin-apple-notes"],
 
@@ -713,6 +725,8 @@
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
+    "@kore/mcp-server/@types/bun": ["@types/bun@1.3.11", "", { "dependencies": { "bun-types": "1.3.11" } }, "sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg=="],
+
     "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@tobilu/qmd/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
@@ -752,6 +766,8 @@
     "tar/chownr": ["chownr@3.0.0", "", {}, "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g=="],
 
     "wrap-ansi/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "@kore/mcp-server/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
     "cross-spawn/which/isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -1,0 +1,210 @@
+# Kore MCP Setup Guide
+
+Connect any MCP-compatible AI agent to your personal knowledge base via Kore's MCP server.
+
+## Architecture
+
+Kore uses a **daemon-required model** with a **stdio proxy** pattern:
+
+```
+┌──────────────────────┐         stdio          ┌──────────────────┐
+│  MCP Client          │ ◄────────────────────► │  kore mcp        │
+│  (Claude, etc.)      │                         │  (stdio proxy)   │
+└──────────────────────┘                         └────────┬─────────┘
+                                                          │ HTTP
+                                                          ▼
+                                                 ┌──────────────────┐
+                                                 │  Kore Daemon     │
+                                                 │  localhost:3000  │
+                                                 │  /mcp endpoint   │
+                                                 └──────────────────┘
+```
+
+**Two components:**
+
+1. **Kore Daemon** (`kore start`) — the core-api server that runs continuously, managing memories, the search index, and the ingestion queue. The MCP server is embedded in this process at the `/mcp` HTTP endpoint.
+
+2. **stdio Proxy** (`kore mcp`) — a lightweight bridge that translates MCP JSON-RPC over stdio into HTTP requests to the daemon's `/mcp` endpoint. It contains no business logic — all tool execution happens in the daemon.
+
+**Why two components?** MCP clients like Claude Desktop expect to launch a process that speaks MCP over stdio. But Kore's memory system requires a long-running daemon (for the search index, queue worker, consolidation loop, etc.). The stdio proxy bridges these models: the client launches `kore mcp`, which connects to the already-running daemon.
+
+## Prerequisites
+
+1. **Kore daemon running**: Start it with `kore start` (or `bun run apps/core-api/src/index.ts`)
+2. **API key set**: `KORE_API_KEY` must be set in the environment for both the daemon and the proxy
+
+## Generic MCP Client Configuration
+
+Any MCP-compatible client can connect to Kore using the `command` + `args` pattern:
+
+- **Command**: `kore`
+- **Args**: `["mcp"]`
+
+The proxy reads these environment variables:
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KORE_API_URL` | `http://localhost:3000` | Daemon URL |
+| `KORE_API_KEY` | _(required)_ | Bearer token for authentication |
+| `KORE_MCP_PATH` | `/mcp` | HTTP route path on the daemon |
+
+## Claude Desktop
+
+Add to `claude_desktop_config.json` (located at `~/Library/Application Support/Claude/claude_desktop_config.json` on macOS):
+
+```json
+{
+  "mcpServers": {
+    "kore": {
+      "command": "kore",
+      "args": ["mcp"],
+      "env": {
+        "KORE_API_KEY": "your-api-key-here",
+        "KORE_API_URL": "http://localhost:3000"
+      }
+    }
+  }
+}
+```
+
+If `kore` is not on your PATH, use the full path to the binary (e.g., `/usr/local/bin/kore`) or use `bun` directly:
+
+```json
+{
+  "mcpServers": {
+    "kore": {
+      "command": "bun",
+      "args": ["run", "/path/to/kore/apps/mcp-server/index.ts"],
+      "env": {
+        "KORE_API_KEY": "your-api-key-here",
+        "KORE_API_URL": "http://localhost:3000"
+      }
+    }
+  }
+}
+```
+
+## Claude Code
+
+Add to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "kore": {
+      "command": "kore",
+      "args": ["mcp"],
+      "env": {
+        "KORE_API_KEY": "your-api-key-here",
+        "KORE_API_URL": "http://localhost:3000"
+      }
+    }
+  }
+}
+```
+
+Or add it globally via Claude Code's settings.
+
+## Available Tools
+
+Once connected, the agent has access to 6 tools:
+
+### recall
+
+Search the user's personal knowledge base. Returns structured results with metadata (type, intent, confidence, tags).
+
+**Key parameters:**
+- `query` _(string, optional)_ — Semantic search query. If omitted, returns recent memories sorted by date.
+- `type` _(string)_ — Filter: `"place"`, `"media"`, `"note"`, `"person"`
+- `intent` _(string)_ — Filter: `"recommendation"`, `"reference"`, `"personal-experience"`, `"aspiration"`, `"how-to"`
+- `tags` _(string[])_ — Filter to memories matching ALL tags
+- `limit` _(number)_ — Max results (default: 10, max: 50)
+- `offset` _(number)_ — Pagination offset
+- `min_confidence` _(number)_ — Minimum extraction confidence (0.0–1.0)
+- `created_after` / `created_before` _(string)_ — ISO 8601 date filters
+
+### remember
+
+Save noteworthy information to the knowledge base. Content is processed by an LLM to extract key facts.
+
+**Key parameters:**
+- `content` _(string, required)_ — The raw content to save
+- `source` _(string)_ — Where it came from (default: `"agent"`)
+- `suggested_tags` _(string[])_ — Hints for the extraction pipeline
+- `suggested_category` _(string)_ — Category hint (e.g., `"travel/food/ramen"`)
+
+### inspect
+
+Get complete details of a specific memory by ID, including full content and distilled facts.
+
+**Key parameters:**
+- `id` _(string, required)_ — Memory UUID
+
+### insights
+
+Query the synthesized knowledge layer — higher-order documents combining multiple memories.
+
+**Key parameters:**
+- `query` _(string, optional)_ — Semantic search query
+- `insight_type` _(string)_ — Filter: `"cluster_summary"`, `"evolution"`, `"contradiction"`, `"connection"`
+- `status` _(string)_ — Filter: `"active"`, `"evolving"`, `"degraded"` (default: `"active"`)
+- `limit` _(number)_ — Max results (default: 5, max: 20)
+
+### health
+
+Check system health: memory counts, queue status, search index state, sync status.
+
+_No parameters._
+
+### consolidate
+
+Trigger knowledge synthesis — clusters related memories into insight documents.
+
+**Key parameters:**
+- `dry_run` _(boolean)_ — Preview only, don't write files (default: false)
+
+## Environment Variables Reference
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `KORE_API_URL` | `http://localhost:3000` | Base URL of the Kore daemon |
+| `KORE_API_KEY` | _(required)_ | Bearer token for API authentication |
+| `KORE_MCP_ENABLED` | `true` | Enable/disable the embedded MCP server on core-api |
+| `KORE_MCP_PATH` | `/mcp` | HTTP route path for the MCP endpoint |
+| `KORE_MCP_DEFAULT_RECALL_LIMIT` | `10` | Default limit for recall results |
+| `KORE_MCP_MIN_SCORE` | `0.0` | Minimum QMD relevance score threshold |
+
+## Troubleshooting
+
+### "Kore daemon is not running"
+
+The stdio proxy checks the daemon's health endpoint on startup. If it can't reach the daemon, it exits with this error.
+
+**Fix:** Start the daemon first:
+```bash
+kore start
+# or
+bun run apps/core-api/src/index.ts
+```
+
+### `/mcp` endpoint unreachable (HTTP errors)
+
+If the daemon is running but `/mcp` returns errors:
+
+1. **Check `KORE_MCP_ENABLED`** — ensure it's not set to `false` in the daemon's environment
+2. **Check `KORE_API_KEY`** — the proxy and daemon must use the same key
+3. **Check `KORE_API_URL`** — ensure the proxy is pointing to the correct host/port
+
+### No results from `recall`
+
+1. **Memories exist?** Run `kore health` to check memory counts
+2. **Index ready?** Check if `index.status` is `"ok"` and `index.embedded` > 0
+3. **Filters too narrow?** Try broadening: remove `type`/`intent` filters, lower `min_confidence`
+4. **Query too specific?** Try shorter, broader search terms
+
+### Agent not seeing tools
+
+Ensure the MCP client configuration is correct:
+- `command` points to a valid `kore` binary or `bun` with the correct path
+- `env` includes `KORE_API_KEY`
+- The daemon is running and healthy


### PR DESCRIPTION
Closes #86

### Summary
Implements a lightweight stdio-to-HTTP proxy that bridges MCP JSON-RPC over stdio to the Kore daemon's /mcp endpoint, enabling any MCP-compatible agent to connect without network configuration.

Changes:
- apps/mcp-server/index.ts: stdio proxy using MCP SDK Client+Server bridge pattern with StreamableHTTPClientTransport, health check on startup, KORE_API_KEY auth
- apps/mcp-server/package.json: minimal deps (only @modelcontextprotocol/sdk)
- apps/cli/src/commands/mcp.ts + index.ts: new `kore mcp` CLI command
- .env.example: added KORE_MCP_ENABLED, KORE_MCP_PATH, KORE_MCP_DEFAULT_RECALL_LIMIT, KORE_MCP_MIN_SCORE
- docs/mcp-setup.md: architecture overview, generic MCP client config, Claude Desktop + Claude Code examples, tool reference, env var reference, troubleshooting
